### PR TITLE
autocomplete with no save on vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ Then update neovim plugins with :UpdateRemotePlugins
 
 
 command         |   description                                                | vim | neovim
-----------------|--------------------------------------------------------------|-----|-------
+----------------|--------------------------------------------------------------|-----|-----------------
 EnType          | displays type under cursor                                   |  x  |   x
 EnDocUri        | displays documentation url under cursor                      |  x  |   x
 EnDocBrowse     | launch $BROWSER (env variable) documentation url             |  x  |   x
 EnTypeCheck     | launch a check on current file (launched on save)            |  x  |   x
-EnCompleteFunc  | get an autocompletion menu (via ctrl+X ctrl+U) - blocking    |  x  |   x
+EnCompleteFunc  | get an autocompletion menu (via ctrl+X ctrl+U) - blocking    |  x  |   must save
 
 
 # design

--- a/ensime_bridge.gemspec
+++ b/ensime_bridge.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'ensime_bridge'
-  s.version     = '0.0.1'
+  s.version     = '0.0.2'
   s.executables << "ensime_bridge"
   s.date        = '2015-08-31'
   s.summary     = "ensime bridge"

--- a/ftplugin/scala_ensime.vim
+++ b/ftplugin/scala_ensime.vim
@@ -1,6 +1,6 @@
 fun EnSetup()
     highlight EnError ctermbg=red
-ruby <<EOF
+    ruby <<EOF
     $en_matches = []
     $browse = true
 EOF
@@ -92,7 +92,13 @@ fun EnPathStartSize(what)
     call EnSend(a:what." \"".expand('%:p')."\", ".line('.').", ".b.", ".s)
 endfun
 fun EnComplete()
-    call EnSend("complete \"".expand('%:p')."\", ".line('.').", ".col('.'))
+    ruby <<EOF
+    require 'base64'
+    content = VIM.evaluate('join(getline(1, "$"), "\n")')
+    content = Base64.encode64(content).gsub("\n", "!EOL!")
+    VIM.command("let g:encontent = '#{content}'")
+EOF
+    call EnSend("complete \"".expand('%:p')."\", ".line('.').", ".col('.').", \"".g:encontent."\"")
 endfun
 fun EnDocUri()
     call EnPathStartSize("doc_uri")
@@ -134,6 +140,7 @@ fun! EnCompleteFunc(findstart, base)
         return res 
     endif 
 endfun 
+call EnSetup()
 " via ctrl+X ctrl+U
 set completefunc=EnCompleteFunc
 command! -nargs=0 EnComplete call EnComplete()

--- a/lib/ensime_bridge.rb
+++ b/lib/ensime_bridge.rb
@@ -2,6 +2,7 @@
 require 'websocket-eventmachine-client'
 require 'json'
 require 'thread'
+require 'base64'
 require_relative 'ensime'
 class EnsimeBridge
     attr_accessor :socket
@@ -134,10 +135,14 @@ class EnsimeBridge
     def doc_uri path, row, col, size
         at_point "DocUri", path, row, col, size, "point"
     end
-    def complete path, row, col
+    def complete path, row, col, contents = nil
         i = to_position path, row, col
+        fileinfo = {"file"=>path}
+        if contents
+            fileinfo["contents"] = Base64.decode64(contents.gsub("!EOL!", "\n"))
+        end
         req({"point"=>i, "maxResults"=>100,"typehint"=>"CompletionsReq",
-            "caseSens"=>true,"fileInfo"=>{"file"=>path},"reload"=>false})
+            "caseSens"=>true,"fileInfo"=> fileinfo,"reload"=>false})
     end
     def typecheck path
         req({"typehint"=>"TypecheckFilesReq","files" => [path]})


### PR DESCRIPTION
Until now, to autocomplete, you had to save current buffer first.
This fixes that on vim (not on neovim)