### PR TITLE
symbol command doesn't open definition

### DIFF
--- a/autoload/ensime.vim.py
+++ b/autoload/ensime.vim.py
@@ -159,7 +159,7 @@ class EnsimeClient(object):
     # @neovim.command('EnSymbol', range='', nargs='*', sync=True)
     def symbol(self, args, range = None):
         self.log("symbol: in")
-        self.symbol_at_point_req(True)
+        self.symbol_at_point_req(False)
     # @neovim.command('EnDocUri', range='', nargs='*', sync=True)
     def doc_uri(self, args, range = None):
         self.log("doc_uri: in")

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -159,7 +159,7 @@ class EnsimeClient(object):
     # @neovim.command('EnSymbol', range='', nargs='*', sync=True)
     def symbol(self, args, range = None):
         self.log("symbol: in")
-        self.symbol_at_point_req(True)
+        self.symbol_at_point_req(False)
     # @neovim.command('EnDocUri', range='', nargs='*', sync=True)
     def doc_uri(self, args, range = None):
         self.log("doc_uri: in")


### PR DESCRIPTION
`:EnSymbol` command should not open new buffer.
This is the fix for this behavior.