### PR TITLE
add inspect type command

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -70,6 +70,10 @@ function! ensime#com_en_symbol(args, range) abort
     return s:call_plugin('com_en_symbol', [a:args, a:range])
 endfunction
 
+function! ensime#com_en_inspect_type(args, range) abort
+    return s:call_plugin('com_en_inspect_type', [a:args, a:range])
+endfunction
+
 function! ensime#com_en_doc_uri(args, range) abort
     return s:call_plugin('com_en_doc_uri', [a:args, a:range])
 endfunction

--- a/autoload/ensime.vim.py
+++ b/autoload/ensime.vim.py
@@ -160,6 +160,11 @@ class EnsimeClient(object):
     def symbol(self, args, range = None):
         self.log("symbol: in")
         self.symbol_at_point_req(True)
+    # @neovim.command('EnInspectType', range='', nargs='*', sync=True)
+    def inspect_type(self, args, range = None):
+        self.log("inspect_type: in")
+        pos = self.get_position(self.cursor()[0], self.cursor()[1])
+        self.send_request({"point": pos, "typehint": "InspectTypeAtPointReq", "file": self.path(), "range": {"from": pos, "to": pos}})
     # @neovim.command('EnDocUri', range='', nargs='*', sync=True)
     def doc_uri(self, args, range = None):
         self.log("doc_uri: in")
@@ -193,7 +198,6 @@ class EnsimeClient(object):
                 "matchadd(g:EnErrorStyle, '\\%{}l\\%>{}c\\%<{}c')".format(l, c, e)))
             self.message(note["msg"])
     def get_cache_port(self, where):
-        self.log("get_cache_port: in")
         f = open(self.ensime_cache + "/" + where)
         port = f.read()
         f.close()
@@ -227,6 +231,9 @@ class EnsimeClient(object):
             self.handle_string_response(payload)
         elif typehint == "CompletionInfoList":
             self.handle_completion_info_list(payload["completions"])
+        elif typehint == "TypeInspectInfo":
+            self.message(payload["type"]["fullName"])
+
     def send_request(self, request):
         self.log("send_request: in")
         self.send(json.dumps({"callId" : self.callId,"req" : request}))
@@ -384,6 +391,9 @@ class Ensime:
 
     def com_en_symbol(self, args, range = None):
         self.with_current_client(lambda c: c.symbol(args, range))
+
+    def com_en_inspect_type(self, args, range = None):
+        self.with_current_client(lambda c: c.inspect_type(args, range))
 
     def com_en_doc_uri(self, args, range = None):
         self.with_current_client(lambda c: c.doc_uri(args, range))

--- a/plugin/ensime.vim
+++ b/plugin/ensime.vim
@@ -14,6 +14,7 @@ command! -nargs=* -range EnTypeCheck call ensime#com_en_type_check([<f-args>], '
 command! -nargs=* -range EnType call ensime#com_en_type([<f-args>], '')
 command! -nargs=* -range EnDeclaration call ensime#com_en_declaration([<f-args>], '')
 command! -nargs=* -range EnSymbol call ensime#com_en_symbol([<f-args>], '')
+command! -nargs=* -range EnInspectType call ensime#com_en_inspect_type([<f-args>], '')
 command! -nargs=* -range EnDocUri call ensime#com_en_doc_uri([<f-args>], '')
 command! -nargs=* -range EnDocBrowse call ensime#com_en_doc_browse([<f-args>], '')
 command! -nargs=0 -range EnClients call ensime#com_en_clients([<f-args>], '')

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -160,6 +160,11 @@ class EnsimeClient(object):
     def symbol(self, args, range = None):
         self.log("symbol: in")
         self.symbol_at_point_req(True)
+    # @neovim.command('EnInspectType', range='', nargs='*', sync=True)
+    def inspect_type(self, args, range = None):
+        self.log("inspect_type: in")
+        pos = self.get_position(self.cursor()[0], self.cursor()[1])
+        self.send_request({"point": pos, "typehint": "InspectTypeAtPointReq", "file": self.path(), "range": {"from": pos, "to": pos}})
     # @neovim.command('EnDocUri', range='', nargs='*', sync=True)
     def doc_uri(self, args, range = None):
         self.log("doc_uri: in")
@@ -226,6 +231,9 @@ class EnsimeClient(object):
             self.handle_string_response(payload)
         elif typehint == "CompletionInfoList":
             self.handle_completion_info_list(payload["completions"])
+        elif typehint == "TypeInspectInfo":
+            self.message(payload["type"]["fullName"])
+
     def send_request(self, request):
         self.log("send_request: in")
         self.send(json.dumps({"callId" : self.callId,"req" : request}))
@@ -389,6 +397,10 @@ class Ensime:
     @neovim.command('EnSymbol', range='', nargs='*', sync=True)
     def com_en_symbol(self, args, range = None):
         self.with_current_client(lambda c: c.symbol(args, range))
+
+    @neovim.command('EnInspectType', range='', nargs='*', sync=True)
+    def com_en_inspect_type(self, args, range = None):
+        self.with_current_client(lambda c: c.inspect_type(args, range))
 
     @neovim.command('EnDocUri', range='', nargs='*', sync=True)
     def com_en_doc_uri(self, args, range = None):


### PR DESCRIPTION
This patch adds `:EnInspectType` command to show class info on a symbol under cursor.