### PR TITLE
Fix ReadMe install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ All the following commands should be run from your scala directory.
 
 First you need ensime sbt plugin:    
     
-    $ echo addSbtPlugin("org.ensime" % "ensime-sbt" % "0.1.7") \
+    $ echo 'addSbtPlugin("org.ensime" % "ensime-sbt" % "0.1.7")' \
         >> ~/.sbt/0.13/plugins/plugins.sbt
 
 Then, generate .ensime file:


### PR DESCRIPTION
There was a small typo in the `echo` command of the Read Me instructions, which made the command impossible to run.

This addresses that issue.