### PR TITLE
Additional troubleshooting tips for Vim users

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ ENSIME for the Editor of the Beast (Vim)
 # howto
 
 You need `websocket-client` python package:
-
+    
     $ sudo pip install websocket-client
 
 You should also export your BROWSER variable, for example in your bashrc:
@@ -88,7 +88,7 @@ You need not use `Vundle`. Just go to `~/.vim/bundle` and clone `ensime-vim`.
 
 Inside `~/.vim/bundle/ensime-vim` folder, edit the following file:
 
-  vim ensime_launcher/__init__.py 
+    vim ensime_launcher/__init__.py 
 
 Find the method `build_sbt`. In the `src` string, add blank lines between
 `SBT` statements (though it should not matter for `SBT 0.13.7` onwards, there
@@ -96,19 +96,18 @@ can be problems).
 
 Go back to your project folder and in `build.sbt` add the following:
 
-  resolvers += "Netbeans" at "http://bits.netbeans.org/nexus/content/groups"
-  libraryDependencies ++= Seq(
-  "org.netbeans.api" % "org-netbeans-api-java" % "RELEASE731",
-  "org.netbeans.api" % "org-netbeans-modules-java-source" % "RELEASE731"
-  )
+    resolvers += "Netbeans" at "http://bits.netbeans.org/nexus/content/groups"
+    libraryDependencies ++= Seq(
+    "org.netbeans.api" % "org-netbeans-api-java" % "RELEASE731",
+    "org.netbeans.api" % "org-netbeans-modules-java-source" % "RELEASE731"
+    )
 
 Just go and open a Scala file and first time you will have `SBT` downloading 
 tons of jars and finally you should be able to use `ensime-vim`. Some useful
 tips:
 
-  C-x C-o -- for auto-assist
-  :help ensime-vim -- for other Ensime goodies
-
+    C-x C-o -- for auto-assist
+    :help ensime-vim -- for other Ensime goodies
 
 # integrating with your own plugin
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ First you need ensime sbt plugin:
     $ echo 'addSbtPlugin("org.ensime" % "ensime-sbt" % "0.1.7")' \
         >> ~/.sbt/0.13/plugins/plugins.sbt
 
+Update: You can use the latest ensime-sbt version i.e. 0.2.1. 
+
 Then, generate .ensime file:
 
     $ sbt gen-ensime
@@ -79,6 +81,34 @@ And export them to vim plugin format via:
     $ neo2vim rplugin/python/ensime.py ftplugin/scala_ensime.vim
 
 All merges should be done on dev branch before being merged onto master
+
+# Additional helpful tips for Vim users
+
+You need not use `Vundle`. Just go to `~/.vim/bundle` and clone `ensime-vim`.
+
+Inside `~/.vim/bundle/ensime-vim` folder, edit the following file:
+
+  vim ensime_launcher/__init__.py 
+
+Find the method `build_sbt`. In the `src` string, add blank lines between
+`SBT` statements (though it should not matter for `SBT 0.13.7` onwards, there
+can be problems). 
+
+Go back to your project folder and in `build.sbt` add the following:
+
+  resolvers += "Netbeans" at "http://bits.netbeans.org/nexus/content/groups"
+  libraryDependencies ++= Seq(
+  "org.netbeans.api" % "org-netbeans-api-java" % "RELEASE731",
+  "org.netbeans.api" % "org-netbeans-modules-java-source" % "RELEASE731"
+  )
+
+Just go and open a Scala file and first time you will have `SBT` downloading 
+tons of jars and finally you should be able to use `ensime-vim`. Some useful
+tips:
+
+  C-x C-o -- for auto-assist
+  :help ensime-vim -- for other Ensime goodies
+
 
 # integrating with your own plugin
 


### PR DESCRIPTION
This will help pure vim users when they stumble across "initializing" message due to incomplete ensime-vim installation. 
In my case, I saw an error in generating sbt file by the ensime-vim plugin. Adding blank lines between the sbt statements in the build_sbt method inside ensime_launcher/__init__.py lead to invalid SBT file.  

Thereafter SBT started installing everything (note: I have SBT 0.13.9 and wondered why this matters).

While installing dependencies, some Netbeans modules were not found so added additional settings in my build.sbt and the whole process completed smoothly.

BTW, I just added to the README. Would like to change the the above py file directly if it is ok in future commits.