### PR TITLE
adding EnClasspath command

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -14,20 +14,20 @@ function! ensime#teardown() abort
     return s:call_plugin('teardown', [])
 endfunction
 
-function! ensime#current_client() abort
-    return s:call_plugin('current_client', [])
+function! ensime#current_client(create, quiet, allow_classpath_file_creation) abort
+    return s:call_plugin('current_client', [a:create, a:quiet, a:allow_classpath_file_creation])
 endfunction
 
-function! ensime#client_for(config_path, create) abort
-    return s:call_plugin('client_for', [a:config_path, a:create])
+function! ensime#client_for(config_path, create, quiet, allow_classpath_file_creation) abort
+    return s:call_plugin('client_for', [a:config_path, a:create, a:quiet, a:allow_classpath_file_creation])
 endfunction
 
 function! ensime#find_config_path(path) abort
     return s:call_plugin('find_config_path', [a:path])
 endfunction
 
-function! ensime#with_current_client(proc) abort
-    return s:call_plugin('with_current_client', [a:proc])
+function! ensime#with_current_client(proc, create, quiet, allow_classpath_file_creation) abort
+    return s:call_plugin('with_current_client', [a:proc, a:create, a:quiet, a:allow_classpath_file_creation])
 endfunction
 
 function! ensime#is_scala_file() abort
@@ -120,6 +120,10 @@ endfunction
 
 function! ensime#com_en_debug_start(args, range) abort
     return s:call_plugin('com_en_debug_start', [a:args, a:range])
+endfunction
+
+function! ensime#com_en_classpath(args, range) abort
+    return s:call_plugin('com_en_classpath', [a:args, a:range])
 endfunction
 
 function! ensime#com_en_debug_continue(args, range) abort

--- a/autoload/ensime.vim.py
+++ b/autoload/ensime.vim.py
@@ -86,8 +86,14 @@ class EnsimeClient(object):
         self.log("teardown: in")
         if self.ensime != None and not self.no_teardown:
             self.ensime.stop()
-    def setup(self):
+    def setup(self, quiet = False, allow_classpath_file_creation = False):
         if self.ensime == None:
+            self.log("setup({}, {}) called by {}()".format(quiet, allow_classpath_file_creation, inspect.stack()[1][3]))
+            if not allow_classpath_file_creation and not allow_classpath_file_creation and self.launcher.no_classpath_file(self.config_path):
+                if not quiet:
+                    self.message("please :EnClasspath to initialize ensime classpath")
+                return False
+            self.message("setup: launching ensime")
             self.ensime = self.launcher.launch(self.config_path)
             self.vim.command("set omnifunc=EnCompleteFunc")
         if self.ws == None and self.ensime.is_ready():
@@ -97,12 +103,14 @@ class EnsimeClient(object):
                     self.ensime.http_port()))
             else:
                 self.tell_module_missing("websocket-client")
+        return True
     def tell_module_missing(self, name):
         self.message("{} missing: do a `pip install {}` and restart vim".format(name, name))
     def send(self, what):
         self.log("send: in")
         if self.ws == None:
-            self.message("still initializing")
+            if not self.launcher.no_classpath_file(self.config_path):
+                self.message("still initializing")
         else:
             try:
                 self.log("send: {}".format(what))
@@ -157,6 +165,9 @@ class EnsimeClient(object):
     def type_check_cmd(self, args, range = None):
         self.log("type_check_cmd: in")
         self.type_check("")
+    # @neovim.command('EnClasspath', range='', nargs='*', sync=True)
+    def en_classpath(self, args, range = None):
+        self.log("en_classpath: in")
     # @neovim.command('EnFormatSource', range='', nargs='*', sync=True)
     def format_source(self, args, range = None):
         self.log("type_check_cmd: in")
@@ -331,7 +342,8 @@ class EnsimeClient(object):
         self.vim.command('call feedkeys("f\e")')
     # @neovim.autocmd('CursorMoved', pattern='*.scala', eval='expand("<afile>")', sync=True)
     def cursor_moved(self, filename):
-        self.setup()
+        self.log("cursor moved: in")
+        self.setup(True, False)
         if self.ws == None: return
         self.display_error_if_necessary(filename)
         self.unqueue(filename)
@@ -416,22 +428,24 @@ class Ensime:
         for c in self.clients.values():
             c.teardown(None)
 
-    def current_client(self):
+    def current_client(self, create = True, quiet = False, allow_classpath_file_creation = False):
         config_path = self.find_config_path(self.vim.eval("expand('%:p')"))
         if config_path == None:
             return None
         else:
-            return self.client_for(config_path)
+            return self.client_for(config_path, create, quiet, allow_classpath_file_creation)
 
-    def client_for(self, config_path, create = True):
+    def client_for(self, config_path, create = True, quiet = False, allow_classpath_file_creation = False):
         abs_path = os.path.abspath(config_path)
         if abs_path in self.clients:
             return self.clients[abs_path]
         elif create:
             client = EnsimeClient(self.vim, self.launcher, config_path)
-            self.clients[abs_path] = client
-            client.setup()
-            return client
+            if client.setup(quiet, allow_classpath_file_creation):
+                self.clients[abs_path] = client
+                return client
+            else:
+                return None
         else:
             return None
 
@@ -446,8 +460,8 @@ class Ensime:
         else:
             return self.find_config_path(os.path.dirname(abs_path))
 
-    def with_current_client(self, proc):
-        c = self.current_client()
+    def with_current_client(self, proc, create = True, quiet = False, allow_classpath_file_creation = False):
+        c = self.current_client(create, quiet, allow_classpath_file_creation)
         if c != None:
             return proc(c)
 
@@ -493,6 +507,9 @@ class Ensime:
     def com_en_debug_start(self, args, range = None):
         self.with_current_client(lambda c: c.debug_start(args, range))
 
+    def com_en_classpath(self, args, range = None):
+        self.with_current_client(lambda c: c.en_classpath(args, range), True, False, True)
+
     def com_en_debug_continue(self, args, range = None):
         self.with_current_client(lambda c: c.debug_continue(args, range))
 
@@ -507,7 +524,7 @@ class Ensime:
         self.teardown()
 
     def au_buf_enter(self, filename):
-        self.with_current_client(lambda c: c.buffer_enter(filename))
+        self.with_current_client(lambda c: c.buffer_enter(filename), True, True)
 
     def au_buf_leave(self, filename):
         self.with_current_client(lambda c: c.buffer_leave(filename))
@@ -519,7 +536,7 @@ class Ensime:
         self.with_current_client(lambda c: c.on_cursor_hold(filename))
 
     def au_cursor_moved(self, filename):
-        self.with_current_client(lambda c: c.cursor_moved(filename))
+        self.with_current_client(lambda c: c.cursor_moved(filename), True, True)
 
     def fun_en_complete_func(self, findstart, base = None):
         if base == None:

--- a/doc/ensime-vim.txt
+++ b/doc/ensime-vim.txt
@@ -15,6 +15,7 @@ COMMANDS                                        *ensime-commands*
 These commands are local to the buffers in which they work.
 They should be ran from
 
+:EnClasspath            generates classpath for ensime and launch ensime-server
 :EnType                 displays type under cursor
 :EnSymbol               displays the path where the symbol under cursor was declared
 :EnDeclaration          vsplit window where the symbol under cursor was declared

--- a/ensime_launcher/__init__.py
+++ b/ensime_launcher/__init__.py
@@ -83,10 +83,16 @@ class EnsimeLauncher:
     def classpath_project_dir(self, scala_version):
         return os.path.join(self.base_dir, scala_version)
 
+    def no_classpath_file(self, conf_path):
+        conf = self.parse_conf(conf_path)
+        project_dir = self.classpath_project_dir(conf['scala-version'])
+        classpath_file = os.path.join(project_dir, "classpath")
+        return not os.path.exists(classpath_file)
+
     def load_classpath(self, scala_version, java_home):
         project_dir = self.classpath_project_dir(scala_version)
         classpath_file = os.path.join(project_dir, "classpath")
-        if not os.path.exists(classpath_file):
+        if self.no_classpath_file():
             self.generate_classpath(scala_version, classpath_file)
         return "{}:{}/lib/tools.jar".format(Util.read_file(classpath_file), java_home)
 

--- a/plugin/ensime.vim
+++ b/plugin/ensime.vim
@@ -24,6 +24,7 @@ command! -nargs=* -range EnSuggestImport call ensime#com_en_suggest_import([<f-a
 command! -nargs=* -range EnSetBreak call ensime#com_en_set_break([<f-args>], '')
 command! -nargs=* -range EnClearBreaks call ensime#com_en_clear_breaks([<f-args>], '')
 command! -nargs=* -range EnDebug call ensime#com_en_debug_start([<f-args>], '')
+command! -nargs=* -range EnClasspath call ensime#com_en_classpath([<f-args>], '')
 command! -nargs=* -range EnContinue call ensime#com_en_debug_continue([<f-args>], '')
 command! -nargs=* -range EnBacktrace call ensime#com_en_backtrace([<f-args>], '')
 command! -nargs=0 -range EnClients call ensime#com_en_clients([<f-args>], '')


### PR DESCRIPTION
When starting ensime-vim, if classpath directory was not already generated, do nothing.
When any command is launched, display:
`please :EnClasspath to initialize ensime classpath`
When EnClasspath is launched, generate the classpath directory and start ensime server.