### PR TITLE
Support omnifunc to be invoked with findstart as a number

### DIFF
--- a/autoload/ensime.vim.py
+++ b/autoload/ensime.vim.py
@@ -398,7 +398,7 @@ class EnsimeClient(object):
     # @neovim.function('EnCompleteFunc', sync=True)
     def complete_func(self, findstart, base):
         self.log("complete_func: in {} {}".format(findstart, base))
-        if findstart == '1':
+        if str(findstart) == '1':
             self.complete()
             line = self.vim.eval("getline('.')")
             col = self.cursor()[1]

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -398,7 +398,7 @@ class EnsimeClient(object):
     # @neovim.function('EnCompleteFunc', sync=True)
     def complete_func(self, findstart, base):
         self.log("complete_func: in {} {}".format(findstart, base))
-        if findstart == '1':
+        if str(findstart) == '1':
             self.complete()
             line = self.vim.eval("getline('.')")
             col = self.cursor()[1]


### PR DESCRIPTION
Some times the `omnifunc` is invoked with `findstart` arg as a number `1`. An example of such kind of invocation is YCM semantic completion.

Comparing the argument against string value `'1'` causes to return a list as the result for the first invocation when it has to be a number (cursor position). So it generates an error in the caller, for instance YCM halts for a while (several seconds) and then it shows the following error in the status line:

    Omnifunc returned bad value to YCM! int() argument must be a string or a number, not 'list'

Wrapping `findstart` with `str()` is safer in the case it is a number or a string.