### PR TITLE
EnDeclaration: manually execute autocmds

### DIFF
--- a/autoload/ensime.vim.py
+++ b/autoload/ensime.vim.py
@@ -301,7 +301,7 @@ class EnsimeClient(object):
                 self.log("handle_string_response: browsing doc path {}".format(url))
                 browser = os.environ.get("BROWSER")
                 if browser != None:
-                    subprocess.Popen([browser, url])
+                    subprocess.Popen([browser, url], stderr=subprocess.PIPE, stdout=subprocess.PIPE)
                 else:
                     self.log("handle_string_response: no browser variable defined")
                 self.browse = False
@@ -334,10 +334,10 @@ class EnsimeClient(object):
                 #self.message(payload["declPos"]["file"])
                 if self.open_definition:
                     self.clean_errors()
+                    self.vim.command("doautocmd BufLeave")
                     self.vim.command("{} {}".format("split" if self.split else "e", payload["declPos"]["file"]))
                     self.set_position(payload["declPos"])
-                    self.vim.command("syntax enable")
-                    self.vim.command("filetype detect")
+                    self.vim.command("doautocmd BufRead,BufEnter")
             except KeyError:
                 self.message("symbol not found")
         elif typehint == "IndexerReadyEvent":

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -334,10 +334,10 @@ class EnsimeClient(object):
                 #self.message(payload["declPos"]["file"])
                 if self.open_definition:
                     self.clean_errors()
+                    self.vim.command("doautocmd BufLeave")
                     self.vim.command("{} {}".format("split" if self.split else "e", payload["declPos"]["file"]))
                     self.set_position(payload["declPos"])
-                    self.vim.command("syntax enable")
-                    self.vim.command("filetype detect")
+                    self.vim.command("doautocmd BufRead,BufEnter")
             except KeyError:
                 self.message("symbol not found")
         elif typehint == "IndexerReadyEvent":


### PR DESCRIPTION
Without this change, upon calling EnDeclaration I lose both syntax highlighting and airline coloring in neovim 0.1.1.

AFAICT this happens because autocmds are [apparently not executed when using the API](https://github.com/neovim/neovim/issues/3853), so we have to call them manually.

I have tested this PR with both vim and neovim, and get syntax highlighting after EnDeclaration in both versions.  This might also solve @yazgoo's problems from #124.