### PR TITLE
Changes completion function to support nvim style args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 *.pyc
 .coverage
 htmlcov
+.gitignore
+.ropeproject*
 __pycache__

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -1030,7 +1030,7 @@ class Ensime(object):
         """Invokable function from vim and neovim to perform completion."""
         if self.is_scala_file():
             client.log("{} {}".format(findstart_and_base, base))
-            if not base:
+            if not (isinstance(findstart_and_base, list)) and not base:
                 # Invoked by vim
                 findstart = findstart_and_base
             else:


### PR DESCRIPTION
This addresses #169 , in that it actually causes the omni-complete function to fire in neovim. However, there are still some outstanding issues I'm looking into in #170  that prevent omni-completion from working correctly.