### PR TITLE
Introduces EnSearch and machinery for adding quickfix items

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -82,6 +82,10 @@ function! ensime#com_en_type(args, range) abort
     return s:call_plugin('com_en_type', [a:args, a:range])
 endfunction
 
+function! ensime#com_en_sym_search(args, range) abort
+    return s:call_plugin('com_en_sym_search', [a:args, a:range])
+endfunction
+
 function! ensime#com_en_toggle_fulltype(args, range) abort
     return s:call_plugin('com_en_toggle_fulltype', [a:args, a:range])
 endfunction

--- a/plugin/ensime.vim
+++ b/plugin/ensime.vim
@@ -15,6 +15,7 @@ augroup END
 command! -nargs=* -range EnNoTeardown call ensime#com_en_no_teardown([<f-args>], '')
 command! -nargs=* -range EnTypeCheck call ensime#com_en_type_check([<f-args>], '')
 command! -nargs=* -range EnType call ensime#com_en_type([<f-args>], '')
+command! -nargs=* -range EnSearch call ensime#com_en_sym_search([<f-args>], '')
 command! -nargs=* -range EnFormatSource call ensime#com_en_format_source([<f-args>], '')
 command! -nargs=* -range EnDeclaration call ensime#com_en_declaration([<f-args>], '')
 command! -nargs=* -range EnDeclarationSplit call ensime#com_en_declaration_split([<f-args>], '')

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -48,6 +48,10 @@ class NeovimEnsime(Ensime):
     def com_en_type(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_type(*args, **kwargs)
 
+    @neovim.command('EnSearch', **command_params)
+    def com_en_sym_search(self, *args, **kwargs):
+        super(NeovimEnsime, self).com_en_sym_search(*args, **kwargs)
+
     @neovim.command('EnToggleFullType', **command_params)
     def com_en_toggle_fulltype(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_toggle_fulltype(*args, **kwargs)


### PR DESCRIPTION
This performs an ENSIME  `PublicSymbolSearchReq` and places the top 25 results into the quickfix window, creating a new list. I figured 25 was a pretty reasonable number, although the ENSME search result ordering leaves something to be desired, so its possible you won't have the symbol you're looking for.

The quickfix machinery itself should be useful for other navigation/ find usage commands once we're ready to add those as well.

To run this from NeoVim, make sure to run `:UpdateRemotePlugins`, otherwise `:EnSearch` will not appear as a command.

Addresses #174 