### PR TITLE
Fix start of autocompletion

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -841,11 +841,11 @@ class EnsimeClient(object):
         self.log("complete_func: in {} {}".format(findstart, base))
         if str(findstart) == "1":
             row, col, startcol = detect_row_column_start()
-            if startcol:
-                self.vim_command("write_file")
-                # Make request to get response ASAP
-                self.complete(row, col)
-                self.completion_started = True
+
+            self.vim_command("write_file")
+            # Make request to get response ASAP
+            self.complete(row, col)
+            self.completion_started = True
 
             # We always allow autocompletion, even with empty seeds
             return startcol

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -833,23 +833,22 @@ class EnsimeClient(object):
             row, col = self.cursor()
             start = col
             line = self.vim.current.line
-            # No completion from empty string
-            if start != 0 and line[start - 1] == " ":
-                start = -1
-            else:
-                while start > 0 and line[start - 1] != " ":
-                    start -= 1
-            return row, col, start + 1  # pos in no empty str
+            while start > 0 and line[start - 1] != " ":
+                start -= 1
+            # Start should be 1 when startcol is zero
+            return row, col, start if start else 1
 
         self.log("complete_func: in {} {}".format(findstart, base))
         if str(findstart) == "1":
             row, col, startcol = detect_row_column_start()
-            if startcol != -1:
+            if startcol:
                 self.vim_command("write_file")
                 # Make request to get response ASAP
                 self.complete(row, col)
                 self.completion_started = True
-            return min(startcol,col)
+
+            # We always allow autocompletion, even with empty seeds
+            return startcol
         else:
             result = []
             # Only handle snd invocation if fst has already been done

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -833,7 +833,7 @@ class EnsimeClient(object):
             row, col = self.cursor()
             start = col
             line = self.vim.current.line
-            while start > 0 and line[start - 1] != " ":
+            while start > 0 and line[start - 1] not in " .":
                 start -= 1
             # Start should be 1 when startcol is zero
             return row, col, start if start else 1


### PR DESCRIPTION
There was a bug that caused the omnicompletion to start the completion one column ahead. This PR fixes this and also adds no constraints to run autocompletion when the user asks for it. For instance, now we allow it even if you don't have written any seed.