### PR TITLE
Fix weird OSX folder rename error

### DIFF
--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -4,6 +4,7 @@ import socket
 import subprocess
 import re
 import time
+import shutil
 
 from ensime_shared.util import Util, catch
 
@@ -47,11 +48,12 @@ class EnsimeProcess(object):
 
 join = os.path.join
 home = os.environ["HOME"]
+
 # Use a new path that is clearer and more user-friendly
 _default_base_dir = join(home, ".config/ensime-vim/")
 _old_base_dir = join(home, ".config/classpath_project_ensime")
 if os.path.isdir(_old_base_dir):
-    os.rename(_old_base_dir, _default_base_dir)
+    shutil.move(_old_base_dir, _default_base_dir)
 
 
 class EnsimeLauncher(object):


### PR DESCRIPTION
When we changed the configuration folder names of ensime-vim, we didn't
check if it was working for OSX. Apparently, the rename operation is
implemented in such a way in this OS that we cannot rename a non-empty
folder with `os.rename`, and we have to use `shutil.move` instead.