### PR TITLE
syntastic integration

### DIFF
--- a/plugin_integrations/syntastic/syntax_checkers/scala/ensime.vim
+++ b/plugin_integrations/syntastic/syntax_checkers/scala/ensime.vim
@@ -1,0 +1,35 @@
+let s:save_cpo = &cpo
+set cpo&vim
+
+function! SyntaxCheckers_scala_ensime_IsAvailable() dict
+    return 1
+endfunction
+
+function! SyntaxCheckers_scala_ensime_GetLocList() dict
+    if exists('b:ensime_scala_notes')
+        return b:ensime_scala_notes
+    else
+        return []
+    endif
+endfunction
+
+function! SyntaxCheckers_scala_ensime_GetHighlightRegex(error)
+    if a:error['len']
+        let lcol = a:error['col'] - 1
+        let rcol = a:error['col'] + a:error['len']
+        let ret = '\%>' . lcol . 'c\%<' . rcol . 'c'
+    else
+        let ret = ''
+    endif
+
+    return ret
+endfunction
+
+call g:SyntasticRegistry.CreateAndRegisterChecker({
+            \ 'filetype': 'scala',
+            \ 'name': 'ensime',
+            \ 'exec': '/bin/true'
+            \ })
+
+let &cpo = s:save_cpo
+unlet s:save_cpo


### PR DESCRIPTION
This is a simple optional Syntastic integration.

Syntastic provides a lot more options to configure the way errors are shown to the end user
(unlike ensime-vim, which just highlights errors in a simplistic way without an ability to configure this highlighting).

This plugin provides a way to integrate with Syntastic if it's available and fall back to built in highlighter if it's not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ensime/ensime-vim/184)
<!-- Reviewable:end -->
