### PR TITLE
Add Interface names to type inspection status line

### DIFF
--- a/doc/ensime-vim.txt
+++ b/doc/ensime-vim.txt
@@ -33,6 +33,7 @@ They should be ran from
 
 :EnClasspath            generates classpath for ensime and launch ensime-server
 :EnType                 displays type under cursor
+:EnInspectType          displays implemented interfaces and the type under cursor
 :EnSearch               search for a public symbol
 :EnSymbol               displays the path where the symbol under cursor was declared
 :EnDeclaration          open buffer where the symbol under cursor was declared

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -425,7 +425,10 @@ class EnsimeClient(object):
 
     def handle_type_inspect(self, call_id, payload):
         """Handler for responses `TypeInspectInfo`."""
-        self.raw_message(payload["type"]["fullName"])
+        interfaces = payload.get("interfaces")
+        ts = [i["type"]["name"] for i in interfaces]
+        prefix = "( " + ", ".join(ts) + " ) => "
+        self.raw_message(prefix + payload["type"]["fullName"])
 
     def show_type(self, call_id, payload):
         """Show type of a variable or scala type."""


### PR DESCRIPTION
This is a small change that causes `:EnInspectType` to display all of the types the inspected type extends/ implements. 