### PR TITLE
Vim passes a base parameter on the 0 callback

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -1082,7 +1082,7 @@ class Ensime(object):
         """Invokable function from vim and neovim to perform completion."""
         if self.is_scala_file():
             client.log("{} {}".format(findstart_and_base, base))
-            if not (isinstance(findstart_and_base, list)) and not base:
+            if not (isinstance(findstart_and_base, list)):
                 # Invoked by vim
                 findstart = findstart_and_base
             else:


### PR DESCRIPTION
Turns out the Vim api switches between no `base` parameter for the initial call to `omniComplete`, and a present `base` for the callback. I was not handling the callback case correctly, and was dropping into the neovim handler, which resulted in the `IndexError`.

Addresses #192