### PR TITLE
Inline local

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -110,6 +110,10 @@ function! ensime#com_en_rename(args, range) abort
     return s:call_plugin('com_en_rename', [a:args, a:range])
 endfunction
 
+function! ensime#com_en_inline(args, range) abort
+    return s:call_plugin('com_en_inline', [a:args, a:range])
+endfunction
+
 function! ensime#com_en_inspect_type(args, range) abort
     return s:call_plugin('com_en_inspect_type', [a:args, a:range])
 endfunction

--- a/plugin/ensime.vim
+++ b/plugin/ensime.vim
@@ -21,6 +21,7 @@ command! -nargs=* -range EnDeclaration call ensime#com_en_declaration([<f-args>]
 command! -nargs=* -range EnDeclarationSplit call ensime#com_en_declaration_split([<f-args>], '')
 command! -nargs=* -range EnSymbol call ensime#com_en_symbol([<f-args>], '')
 command! -nargs=* -range EnRename call ensime#com_en_rename([<f-args>], '')
+command! -nargs=* -range EnInline call ensime#com_en_inline([<f-args>], '')
 command! -nargs=* -range EnInspectType call ensime#com_en_inspect_type([<f-args>], '')
 command! -nargs=* -range EnDocUri call ensime#com_en_doc_uri([<f-args>], '')
 command! -nargs=* -range EnDocBrowse call ensime#com_en_doc_browse([<f-args>], '')

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -116,6 +116,10 @@ class NeovimEnsime(Ensime):
     def com_en_rename(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_rename(*args, **kwargs)
 
+    @neovim.command('EnInline', **command_params)
+    def com_en_inline(self, *args, **kwargs):
+        super(NeovimEnsime, self).com_en_inline(*args, **kwargs)
+
     @neovim.command('EnClients', range='', nargs='0', sync=True)
     def com_en_clients(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_clients(*args, **kwargs)


### PR DESCRIPTION
Implements the `InlineLocal` refactoring from Scala-IDE Refactorings. This simply takes the right side of an assignment to a local `val`, replaces all occurrences of the assigned symbol & removes the assignment.

Addresses #196