### PR TITLE
Autocomplete causes screen flickering

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -1,5 +1,6 @@
 if !has('nvim')
-    execute 'pyfile' expand('<sfile>:p').'.py'
+    execute 'silent! pyfile' expand('<sfile>:p').'.py'
+    execute ':redraw!'
 endif
 
 function! ensime#client_keys() abort


### PR DESCRIPTION
Add ":silent!" and redraw fix annoying messages caused by execution of external script. Always use it when user are not interested in command output.