### PR TITLE
Introduces basic Package Inspector

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -82,6 +82,10 @@ function! ensime#com_en_type(args, range) abort
     return s:call_plugin('com_en_type', [a:args, a:range])
 endfunction
 
+function! ensime#com_en_package_inspect(args, range) abort
+    return s:call_plugin('com_en_package_inspect', [a:args, a:range])
+endfunction
+
 function! ensime#com_en_sym_search(args, range) abort
     return s:call_plugin('com_en_sym_search', [a:args, a:range])
 endfunction

--- a/plugin/ensime.vim
+++ b/plugin/ensime.vim
@@ -17,6 +17,7 @@ command! -nargs=* -range EnTypeCheck call ensime#com_en_type_check([<f-args>], '
 command! -nargs=* -range EnType call ensime#com_en_type([<f-args>], '')
 command! -nargs=* -range EnSearch call ensime#com_en_sym_search([<f-args>], '')
 command! -nargs=* -range EnFormatSource call ensime#com_en_format_source([<f-args>], '')
+command! -nargs=* -range EnShowPackage call ensime#com_en_package_inspect([<f-args>], '')
 command! -nargs=* -range EnDeclaration call ensime#com_en_declaration([<f-args>], '')
 command! -nargs=* -range EnDeclarationSplit call ensime#com_en_declaration_split([<f-args>], '')
 command! -nargs=* -range EnSymbol call ensime#com_en_symbol([<f-args>], '')

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -104,6 +104,10 @@ class NeovimEnsime(Ensime):
     def com_en_classpath(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_classpath(*args, **kwargs)
 
+    @neovim.command('EnShowPackage', **command_params)
+    def com_en_package_inspect(self, *args, **kwargs):
+        super(NeovimEnsime, self).com_en_package_inspect(*args, **kwargs)
+
     @neovim.command('EnContinue', **command_params)
     def com_en_debug_continue(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_debug_continue(*args, **kwargs)


### PR DESCRIPTION
This introduces a very simple package inspector. Users provide a full package name, and the resulting class names are added to a new vertical split.

There are a few obvious enhancements for things like jumping to the declaration, finding all usages (via grep), displaying symbol type, coloring results, etc... that I think would be really useful either as community additions or things I'll get to when I have the opportunity.

#190