### PR TITLE
Double Quote FeedKeys expr-quote \e for Error Bell

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -1045,7 +1045,7 @@ class EnsimeClient(object):
         # Make sure any plugin overrides this
         self.vim_command("set_updatetime")
         # Keys with no effect, just retrigger CursorHold
-        self.vim.command("call feedkeys('f\e')")
+        self.vim.command('call feedkeys("f\e")')
 
     def on_cursor_move(self, filename):
         """Handler for event CursorMoved."""


### PR DESCRIPTION
Looks like the quotes were flipped for the escape character. I haven't been able to test this in Vim yet (my docker env is borked).