### PR TITLE
Implements expected symbol opening from Packages

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -80,6 +80,7 @@ class EnsimeClient(object):
             self.vim_command("set_updatetime")
             self.vim_command("set_ensime_completion")
             self.vim.command("autocmd FileType package_info nnoremap <buffer> <Space> :EnPackageDecl<CR>")
+            self.vim.command("autocmd FileType package_info  setlocal splitright")
 
         def setup_logger_and_paths():
             """Set up paths and logger."""
@@ -468,6 +469,7 @@ class EnsimeClient(object):
 
         symbolName = ".".join(fqn)
         self.symbol_by_name([symbolName])
+        self.unqueue(should_wait=True)
 
     def to_quickfix_item(self, file_name, line_number, message, tpe):
         return { "filename" : file_name,
@@ -986,7 +988,7 @@ class EnsimeClient(object):
              "files": [self.path()]})
         self.clean_errors()
 
-    def unqueue(self, filename, timeout=10, should_wait=False):
+    def unqueue(self, timeout=10, should_wait=False):
         """Unqueue all the received ensime responses for a given file."""
         def trigger_callbacks(_json):
             for name in self.receive_callbacks:
@@ -1023,7 +1025,7 @@ class EnsimeClient(object):
         """Unqueue messages and give feedback to user (if necessary)."""
         if self.running and self.ws:
             self.lazy_display_error(filename)
-            self.unqueue(filename)
+            self.unqueue()
 
     def lazy_display_error(self, filename):
         """Display error when user is over it."""
@@ -1095,7 +1097,7 @@ class EnsimeClient(object):
             if self.completion_started:
                 self.vim_command("until_first_char_word")
                 # Unqueing messages until we get suggestions
-                self.unqueue("", timeout=self.completion_timeout, should_wait=True)
+                self.unqueue(timeout=self.completion_timeout, should_wait=True)
                 suggestions = self.suggestions or []
                 self.log("complete_func: suggests in {}".format(suggestions))
                 for m in suggestions:


### PR DESCRIPTION
It took a bit more exploring than I expected to get the synchronous behavior that I wanted, but I'm pretty happy with the final product. Upon hitting `<Space>` a request for the symbol under cursor is sent to the server & the client will wait a few seconds for the response. 

The response file is opened in a new vertical buffer immediately to the right of the package inspector.

An alternative solution to calling `unqueue(shouldWait=true)` would have been to add the `CursorHold` handler to the `package_info` filetype, but that felt unclear as a slow response would let users hop back to their previous buffer and move around before being pulled to the new window.

Addresses #223