### PR TITLE
Show friendly error message for PackageInspector w/o fqn

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -749,6 +749,10 @@ class EnsimeClient(object):
             "file": self.path()})
 
     def inspect_package(self, args):
+        if not args:
+            msg = commands["display_message"].format("Must provide a fully qualifed package name")
+            self.vim.command(msg)
+            return
         self.send_request({
             "typehint": "InspectPackageByPathReq",
             "path": args[0]


### PR DESCRIPTION
Not much to this one, just adding a quick error message explaining how to use the package inspector.