### PR TITLE
EnAddImport & EnOrganizeImports commands

### DIFF
--- a/doc/ensime-vim.txt
+++ b/doc/ensime-vim.txt
@@ -53,6 +53,8 @@ They should be ran from
 :EnDebug host port      attach to the specified debugging target
 :EnContinue             continue debugging after pause
 :EnBacktrace            show backtrace when execution is paused in a new buffer
+:EnAddImport            add import statement for given symbol
+:EnOrganizeImports      reorganize (sort and group) import statements
 
 PACKAGE INSPECTOR                               *ensime-package-inspector*
 

--- a/plugin/ensime.vim
+++ b/plugin/ensime.vim
@@ -35,6 +35,8 @@ command! -nargs=* -range EnContinue call ensime#com_en_debug_continue([<f-args>]
 command! -nargs=* -range EnBacktrace call ensime#com_en_backtrace([<f-args>], '')
 command! -nargs=0 -range EnClients call ensime#com_en_clients([<f-args>], '')
 command! -nargs=* -range EnToggleFullType call ensime#com_en_toggle_fulltype([<f-args>], '')
+command! -nargs=* -range EnOrganizeImports call ensime#com_en_organize_imports([<f-args>], '')
+command! -nargs=* -range EnAddImport call ensime#com_en_add_import([<f-args>], '')
 
 function! EnCompleteFunc(a, b) abort
     return ensime#fun_en_complete_func(a:a, a:b)

--- a/plugin_integrations/syntastic/syntax_checkers/scala/ensime.vim
+++ b/plugin_integrations/syntastic/syntax_checkers/scala/ensime.vim
@@ -16,8 +16,8 @@ endfunction
 function! SyntaxCheckers_scala_ensime_GetHighlightRegex(error)
     if a:error['len']
         let lcol = a:error['col'] - 1
-        let rcol = a:error['col'] + a:error['len']
-        let ret = '\%>' . lcol . 'c\%<' . rcol . 'c'
+        let rcol = a:error['col'] + a:error['len'] - 1
+        let ret = '\%>' . lcol . 'v\%<' . rcol . 'v'
     else
         let ret = ''
     endif

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -132,6 +132,14 @@ class NeovimEnsime(Ensime):
     def com_en_inline(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_inline(*args, **kwargs)
 
+    @neovim.command('EnOrganizeImports', **command_params)
+    def com_en_organize_imports(self, *args, **kwargs):
+        super(NeovimEnsime, self).com_en_organize_imports(*args, **kwargs)
+
+    @neovim.command('EnAddImport', **command_params)
+    def com_en_add_import(self, *args, **kwargs):
+        super(NeovimEnsime, self).com_en_add_import(*args, **kwargs)
+
     @neovim.command('EnClients', range='', nargs='0', sync=True)
     def com_en_clients(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_clients(*args, **kwargs)


### PR DESCRIPTION
I'm not sure about using `ensime-server`'s AddImport command to add import instead of direct vim commands, hence, this functionality is in a separate commit, so we can remove it if you don't like it.

Also, the 44b0f43 commit contains a small fix for highlighting Unicode text.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ensime/ensime-vim/230)
<!-- Reviewable:end -->
