### PR TITLE
Change EnPackageDecl to a function

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -99,8 +99,8 @@ function! ensime#com_en_declaration_split(args, range) abort
     return s:call_plugin('com_en_declaration_split', [a:args, a:range])
 endfunction
 
-function! ensime#com_en_package_decl(args, range) abort
-    return s:call_plugin('com_en_package_decl', [a:args, a:range])
+function! ensime#fun_en_package_decl(args, range) abort
+    return s:call_plugin('fun_en_package_decl', [a:args, a:range])
 endfunction
 
 function! ensime#com_en_symbol_by_name(args, range) abort

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -63,6 +63,7 @@ commands = {
     "syntastic_show_notes": "silent SyntasticCheck ensime",
     "get_cursor_word": 'expand("<cword>")',
     "select_item_list": 'inputlist({})',
+    "append_line": 'call append({}, {!r})'
 }
 
 
@@ -78,7 +79,7 @@ class EnsimeClient(object):
             self.vim_command("highlight_enerror")
             self.vim_command("set_updatetime")
             self.vim_command("set_ensime_completion")
-            self.vim.command("autocmd FileType package_info nnoremap <buffer> <Space> :EnPackageDecl<CR>")
+            self.vim.command("autocmd FileType package_info nnoremap <buffer> <Space> :call EnPackageDecl()<CR>")
             self.vim.command("autocmd FileType package_info  setlocal splitright")
 
         def setup_logger_and_paths():
@@ -1269,7 +1270,7 @@ class Ensime(object):
         client.symbol_by_name(args, range)
 
     @execute_with_client()
-    def com_en_package_decl(self, client, args, range=None):
+    def fun_en_package_decl(self, client, args, range=None):
         client.open_decl_for_inspector_symbol()
 
     @execute_with_client()

--- a/plugin/ensime.vim
+++ b/plugin/ensime.vim
@@ -19,7 +19,6 @@ command! -nargs=* -range EnShowPackage call ensime#com_en_package_inspect([<f-ar
 command! -nargs=* -range EnDeclaration call ensime#com_en_declaration([<f-args>], '')
 command! -nargs=* -range EnDeclarationSplit call ensime#com_en_declaration_split([<f-args>], '')
 command! -nargs=* -range EnSymbolByName call ensime#com_en_symbol_by_name([<f-args>], '')
-command! -nargs=* -range EnPackageDecl call ensime#com_en_package_decl([<f-args>], '')
 command! -nargs=* -range EnSymbol call ensime#com_en_symbol([<f-args>], '')
 command! -nargs=* -range EnRename call ensime#com_en_rename([<f-args>], '')
 command! -nargs=* -range EnInline call ensime#com_en_inline([<f-args>], '')
@@ -38,6 +37,10 @@ command! -nargs=* -range EnToggleFullType call ensime#com_en_toggle_fulltype([<f
 command! -nargs=* -range EnOrganizeImports call ensime#com_en_organize_imports([<f-args>], '')
 command! -nargs=* -range EnAddImport call ensime#com_en_add_import([<f-args>], '')
 
+function! EnPackageDecl() abort
+  return ensime#fun_en_package_decl()
+endfunction
+  
 function! EnCompleteFunc(a, b) abort
     return ensime#fun_en_complete_func(a:a, a:b)
 endfunction

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -124,9 +124,9 @@ class NeovimEnsime(Ensime):
     def com_en_rename(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_rename(*args, **kwargs)
 
-    @neovim.command('EnPackageDecl', **command_params)
-    def com_en_package_decl(self, *args, **kwargs):
-        super(NeovimEnsime, self).com_en_package_decl(*args, **kwargs)
+    @neovim.function('EnPackageDecl', sync=True)
+    def fun_en_package_decl(self, *args, **kwargs):
+        super(NeovimEnsime, self).fun_en_package_decl(*args, **kwargs)
 
     @neovim.command('EnInline', **command_params)
     def com_en_inline(self, *args, **kwargs):


### PR DESCRIPTION
This removes the `EnPackageDecl` wart from the plugin by moving it into a function where it belongs. I'm curious whether you ( @ches & @jvican ) think this solution is adequate. 

I also restored the `append_line` cmd to the plugin's command lookup, looks like it was removed as part of the import suggestions.

Addresses #240, #239 & #231.