### PR TITLE
Fix drone.io build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -2,5 +2,5 @@ build:
   image: ensime/ensime:latest
   pull: true
   commands:
-    - pip install python-coveralls
+    - pip install python-coveralls sexpdata
     - python spec/ensime.py


### PR DESCRIPTION
The drone.io CI build is failing due to sexpdata not being installed. This should fix it.