### PR TITLE
Add default for Package Inspector

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -739,7 +739,7 @@ class EnsimeClient(DebuggerClient, object):
     def inspect_package(self, args):
         pkg = None
         if not args:
-            pkg = Util.extract_packageName(self.vim.current.buffer)
+            pkg = Util.extract_package_name(self.vim.current.buffer)
             msg = commands["display_message"].format("Using Currently Focused Package")
             self.vim.command(msg)
         else:

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -737,13 +737,16 @@ class EnsimeClient(DebuggerClient, object):
             "file": self.path()})
 
     def inspect_package(self, args):
+        pkg = None
         if not args:
-            msg = commands["display_message"].format("Must provide a fully qualifed package name")
+            pkg = Util.extract_packageName(self.vim.current.buffer)
+            msg = commands["display_message"].format("Using Currently Focused Package")
             self.vim.command(msg)
-            return
+        else:
+            pkg = args[0]
         self.send_request({
             "typehint": "InspectPackageByPathReq",
-            "path": args[0]
+            "path": pkg
         })
 
     def open_declaration(self, args, range=None):

--- a/ensime_shared/util.py
+++ b/ensime_shared/util.py
@@ -21,6 +21,22 @@ class Util:
         if not os.path.exists(path):
             os.makedirs(path)
 
+    @staticmethod
+    def extract_packageName(lines):
+        foundPacakge = False
+        package = ""
+
+        for line in lines:
+            if "package" not in line and not foundPacakge:
+                continue
+            elif "package" in line:
+                if not package:
+                    package = line.split("package ")[-1].replace("\n", "")
+                else:
+                    package += "." + line.split("package ")[-1].replace("\n", "")
+            else:
+                break
+        return package
 
 @contextmanager
 def catch(exception, handler=lambda e: None):
@@ -37,3 +53,4 @@ def module_exists(module_name):
         __import__(module_name)
         res = True
     return res
+

--- a/ensime_shared/util.py
+++ b/ensime_shared/util.py
@@ -22,7 +22,7 @@ class Util:
             os.makedirs(path)
 
     @staticmethod
-    def extract_packageName(lines):
+    def extract_package_name(lines):
         foundPacakge = False
         package = ""
 

--- a/ensime_shared/util.py
+++ b/ensime_shared/util.py
@@ -23,11 +23,11 @@ class Util:
 
     @staticmethod
     def extract_package_name(lines):
-        foundPacakge = False
+        found_package = False
         package = ""
 
         for line in lines:
-            if "package" not in line and not foundPacakge:
+            if "package" not in line and not found_package:
                 continue
             elif "package" in line:
                 if not package:


### PR DESCRIPTION
This is an imperfect parser that extracts the current package name from a Scala or Java file, as well as the plumbing to use it for the package inspector.

Previously, we were requiring users to type the FQN they wanted to explore. Now simply running `EnShowPackage` will explore the current package. Hopefully this is a big improvement in usability.

Addresses #233 