### PR TITLE
Mark background thread as a daemon.

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -142,7 +142,7 @@ class EnsimeClient(DebuggerClient, object):
         self.debug_thread_id = None
         self.running = True
 
-        thread = Thread(target=self.receive_messages, args=())
+        thread = Thread(target=self.queue_poll, args=())
         thread.daemon = True
         thread.start()
 

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -141,7 +141,10 @@ class EnsimeClient(DebuggerClient, object):
 
         self.debug_thread_id = None
         self.running = True
-        Thread(target=self.queue_poll, args=()).start()
+
+        thread = Thread(target=self.receive_messages, args=())
+        thread.daemon = True
+        thread.start()
 
         self.handlers = {}
         self.register_responses_handlers()


### PR DESCRIPTION
Trivial fix.

This prevents the app from hanging on quit due to race conditions in how shutdown is handled.

I'd really like to fix the race conditions, but I'm having a hard time figuring out how all the various `running` / `shutdown` / etc. flags interoperate.