### PR TITLE
Avoid moving cursor in `complete_func`. Closes #238

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -1099,7 +1099,6 @@ class EnsimeClient(DebuggerClient, object):
             result = []
             # Only handle snd invocation if fst has already been done
             if self.completion_started:
-                self.vim_command("until_first_char_word")
                 # Unqueing messages until we get suggestions
                 self.unqueue(timeout=self.completion_timeout, should_wait=True)
                 suggestions = self.suggestions or []


### PR DESCRIPTION
It's not needed when called from __Vim__ (tested
with `Ctrl-x Ctrl-o` and double checked Vim's documentation,
it's not in `complete-functions` specifications), but it breaks
omnicompletion when called from __deoplete__.  

With this fix Ensime completion can be configured as
`g:deoplete#omni#input_patterns` instead of
`g:deoplete#omni_patterns`. See 'FAQ' in __deoplete__
documentation to know more about the advantages.  

Sample config:  
```VimL
let g:deoplete#omni#input_patterns = {}
let g:deoplete#omni#input_patterns.scala = '[^. *\t]\.\w*'
```