### PR TITLE
Java support

### DIFF
--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -18,7 +18,7 @@ import neovim
 
 # Params for autocmd by default
 autocmd_params = {
-    "pattern": "*.scala|*.java",
+    "pattern": "*.scala",
     "eval": 'expand("<afile>")',
     "sync": True
 }


### PR DESCRIPTION
Removes an unnecessary autocmd autoparam I had added yesterday. The `java` condition seems to be causing problems.