### PR TITLE
Consitently place the log file in .ensime_cache

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -105,9 +105,12 @@ class EnsimeClient(DebuggerClient, object):
             self.config_path = osp.abspath(config_path)
             config_dirname = osp.dirname(self.config_path)
             self.ensime_cache = osp.join(config_dirname, ".ensime_cache")
-            if not osp.isdir(self.ensime_cache):
-                os.mkdir(self.ensime_cache)
             self.log_dir = self.ensime_cache
+            if not osp.isdir(self.ensime_cache):
+                try:
+                    os.mkdir(self.ensime_cache)
+                except OSError as exception:
+                    self.log_dir = "/tmp/"
             self.log_file = os.path.join(self.log_dir, "ensime-vim.log")
             with open(self.log_file, "w") as f:
                 now = datetime.datetime.now()

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -105,8 +105,9 @@ class EnsimeClient(DebuggerClient, object):
             self.config_path = osp.abspath(config_path)
             config_dirname = osp.dirname(self.config_path)
             self.ensime_cache = osp.join(config_dirname, ".ensime_cache")
-            self.log_dir = self.ensime_cache \
-                if osp.isdir(self.ensime_cache) else "/tmp/"
+            if not osp.isdir(self.ensime_cache):
+                os.mkdir(self.ensime_cache)
+            self.log_dir = self.ensime_cache
             self.log_file = os.path.join(self.log_dir, "ensime-vim.log")
             with open(self.log_file, "w") as f:
                 now = datetime.datetime.now()


### PR DESCRIPTION
We are placing the log file in `tmp` if `.ensime_cache` doesn't exists. This changes that and tries to create `.ensime_cache` folder.

Please advice if I should handle the case where folder creation fails