### PR TITLE
Fix missing function shims for standard Vim

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -119,6 +119,14 @@ function! ensime#com_en_inline(args, range) abort
     return s:call_plugin('com_en_inline', [a:args, a:range])
 endfunction
 
+function! ensime#com_en_organize_imports(args, range) abort
+    return s:call_plugin('com_en_organize_imports', [a:args, a:range])
+endfunction
+
+function! ensime#com_en_add_import(args, range) abort
+    return s:call_plugin('com_en_add_import', [a:args, a:range])
+endfunction
+
 function! ensime#com_en_inspect_type(args, range) abort
     return s:call_plugin('com_en_inspect_type', [a:args, a:range])
 endfunction


### PR DESCRIPTION
Pretty straightforward, a couple of function shims were missing on the standard Vim side, so the `:EnAddImport` and `:EnOrganizeImports` commands weren't working.