### PR TITLE
Make qualified vs. shallow types mode actually work consistently on type inspections

### DIFF
--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -8,8 +8,8 @@ feedback = {
     "displayed_type": "The type {} has been displayed",
     "failed_refactoring":
         "The refactoring could not be applied (more info at logs)",
-    "fulltype_display_on": "[ensime] Qualified type display enabled",
-    "fulltype_display_off": "[ensime] Qualified type display disabled",
+    "full_types_enabled_on": "[ensime] Qualified type display enabled",
+    "full_types_enabled_off": "[ensime] Qualified type display disabled",
     "indexer_ready": "Ensime indexer is ready",
     "manual_doc": "Go to {}",
     "missing_debug_class": "You must specify a class to debug",

--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -4,21 +4,24 @@ gconfig = {
 }
 
 feedback = {
-    "start_message": "Ensime server has been started...",
-    "unknown_symbol": "Symbol not found",
-    "indexer_ready": "Ensime indexer is ready",
     "analyzer_ready": "Ensime analyzer is ready",
-    "typechecking": "Typechcking...",
-    "module_missing": "{} missing: do a `pip install {}` and restart vim",
-    "warn_classpath": "Execute :EnClasspath to set a classpath",
-    "missing_debug_class": "You must specify a class to debug",
-    "notify_break": "Execution breaked at {} {}",
     "displayed_type": "The type {} has been displayed",
     "failed_refactoring":
         "The refactoring could not be applied (more info at logs)",
-    "unhandled_response": "Response {} has not been handled",
+    "fulltype_display_on": "[ensime] Qualified type display enabled",
+    "fulltype_display_off": "[ensime] Qualified type display disabled",
+    "indexer_ready": "Ensime indexer is ready",
+    "manual_doc": "Go to {}",
+    "missing_debug_class": "You must specify a class to debug",
+    "module_missing": "{} missing: do a `pip install {}` and restart vim",
+    "notify_break": "Execution breaked at {} {}",
     "spawned_browser": "Opened tab {}",
-    "manual_doc": "Go to {}"}
+    "start_message": "Ensime server has been started...",
+    "typechecking": "Typechecking...",
+    "unhandled_response": "Response {} has not been handled",
+    "unknown_symbol": "Symbol not found",
+    "warn_classpath": "Execute :EnClasspath to set a classpath",
+}
 
 commands = {
     "enerror_matcher": "matchadd('EnErrorStyle', '\\%{}l\\%>{}c\\%<{}c')",

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -555,12 +555,12 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
         if not self.en_format_source_id:
             self.log("handle_string_response: received doc path")
             port = self.ensime.http_port()
-            
+
             url = payload["text"]
-            
-            if not url.startswith("http"): 
+
+            if not url.startswith("http"):
                 url = gconfig["localhost"].format(port, payload["text"])
-            
+
             browse_enabled = self.call_options[call_id].get("browse")
 
             if browse_enabled:
@@ -589,10 +589,11 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
 
     def handle_type_inspect(self, call_id, payload):
         """Handler for responses `TypeInspectInfo`."""
+        style = 'fullName' if self.full_types_enabled else 'name'
         interfaces = payload.get("interfaces")
-        ts = [i["type"]["name"] for i in interfaces]
+        ts = [i["type"][style] for i in interfaces]
         prefix = "( " + ", ".join(ts) + " ) => "
-        self.raw_message(prefix + payload["type"]["fullName"])
+        self.raw_message(prefix + payload["type"][style])
 
     # TODO @ktonga reuse completion suggestion formatting logic
     def show_type(self, call_id, payload):
@@ -713,7 +714,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
         self.symbol_at_point_req(False, True)
 
     def suggest_import(self, args, range=None):
-        self.log("inspect_type: in")
+        self.log("suggest_import: in")
         pos = self.get_position(self.cursor()[0], self.cursor()[1])
         word = self.vim_eval('get_cursor_word')
         req = {"point": pos,

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -108,7 +108,10 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
         self.completion_timeout = 10  # seconds
         self.completion_started = False
         self.en_format_source_id = None
-        self.enable_fulltype = False
+
+        self.full_types_enabled = False
+        """Whether fully-qualified types are displayed by inspections or not"""
+
         self.toggle_teardown = True
         self.connection_attempts = 0
         self.tmp_diff_folder = "/tmp/ensime-vim/diffs/"
@@ -614,7 +617,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
         rtype = payload["resultType"]
         lparams = payload["paramSections"]
         tpe = ""
-        tname = "fullName" if self.enable_fulltype else "name"
+        tname = "fullName" if self.full_types_enabled else "name"
 
         if rtype and lparams:
             for l in lparams:
@@ -682,12 +685,12 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
 
     def toggle_fulltype(self, args, range=None):
         self.log("toggle_fulltype: in")
-        self.enable_fulltype = not self.enable_fulltype
+        self.full_types_enabled = not self.full_types_enabled
 
-        if self.enable_fulltype:
-            self.message("fulltype_display_on")
+        if self.full_types_enabled:
+            self.message("full_types_enabled_on")
         else:
-            self.message("fulltype_display_off")
+            self.message("full_types_enabled_off")
 
     def symbol_at_point_req(self, open_definition, display=False):
         opts = self.call_options.get(self.call_id)

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -684,6 +684,11 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
         self.log("toggle_fulltype: in")
         self.enable_fulltype = not self.enable_fulltype
 
+        if self.enable_fulltype:
+            self.message("fulltype_display_on")
+        else:
+            self.message("fulltype_display_off")
+
     def symbol_at_point_req(self, open_definition, display=False):
         opts = self.call_options.get(self.call_id)
         if opts:

--- a/ensime_shared/spec/features/suggestion_format.feature
+++ b/ensime_shared/spec/features/suggestion_format.feature
@@ -13,22 +13,6 @@ Feature: Format a Completion Suggestion
     | <byname>[ByNameType]   | => ByNameType |
     | <repeated>[VarargType] | VarargType*   |
 
-  Scenario: Format single type parameter
-    Given A list of type parameters:
-      | tparam |
-      | A      |
-    When We concat the type parameters
-    Then We get the format [A]
-
-  Scenario: Format multiple type parameters
-    Given A list of type parameters:
-      | tparam |
-      | A      |
-      | B      |
-      | C      |
-    When We concat the type parameters
-    Then We get the format [A, B, C]
-
   Scenario: Format empty parameters
     Given A list of parameters:
       | pname   | ptype |
@@ -114,7 +98,7 @@ Feature: Format a Completion Suggestion
     When We format the signature
     Then We get the format theCallable(a: A)(implicit b: B)
 
-  Scenario: Convert commpletions to suggestions
+  Scenario: Convert completions to suggestions
     Given We have the following completions:
       | name              | is_callable | ctype        | crtype        | pname | ptype | implicit |
       | nonCallable       | False       | SomeType     |               |       |       |          |

--- a/ensime_shared/spec/features/suggestion_format_steps.py
+++ b/ensime_shared/spec/features/suggestion_format_steps.py
@@ -20,10 +20,6 @@ def get_formatted(step, expected_format):
 def given_a_list_of_type_parameters(step):
     world.tparams = [tp['tparam'] for tp in step.hashes]
 
-@step('We concat the type parameters')
-def concat_type_parameters(step):
-    world.formatted = concat_tparams(world.tparams)
-
 @step('A list of parameters:')
 def given_a_list_of_parameters(step):
     world.params = [(p['pname'], p['ptype']) for p in step.hashes]

--- a/ensime_shared/symbol_format.py
+++ b/ensime_shared/symbol_format.py
@@ -44,11 +44,6 @@ def concat_params(params):
     name_and_types = [": ".join(p) for p in params]
     return ", ".join(name_and_types)
 
-def concat_tparams(tparams):
-    """Return a valid signature from a list of type parameters."""
-    types = ", ".join(tparams)
-    return "[{}]".format(types)
-
 def formatted_param_type(ptype):
     """Return the short name for a type. Special treatment for by-name and var args"""
     pt_name = ptype["name"]


### PR DESCRIPTION
I started out innocently just wanting to add echo feedback when you toggled `:EnToggleFullType` on and off. Then I realized the support for this feature didn't actually work very well.

`:EnType` ignored it completely, always showing qualified types, and that's the command where I most often wanted it disabled. `:EnType` had some other problems too—before this branch, with this (silly) code:

```scala
import scala.concurrent.Future

val fut = Future.successful("bippy")

def carTrip(times: Int, msg: String) = for (_ <- 0 to count) yield msg
carTrip(5, "Are we there yet?")
```

`:EnType` on `fut` would give:

```scala
scala.concurrent.Future[java.lang.String][java.lang.String]
```

Note the duplicate type parameters. For a function type, do `:EnType` on `carTrip` and you'd get this:

```scala
(_0: Int, _1: String) => scala.collection.immutable.IndexedSeq[java.lang.String]
```

Shallow types for the params, qualified for result, and those parameter names are noisy and pretty useless. These will now look like this:

```scala
// The default with shallow types
Future[String]
(Int, String) => IndexedSeq[String]

// With qualified toggled on:
scala.concurrent.Future[java.lang.String]
(scala.Int, java.lang.String) => scala.collection.immutable.IndexedSeq[java.lang.String]
```

Similar changes have been applied to `:EnInspectType`. **Side note**: I think the formatting of using parens and `=>` for the parent types on `:EnInspectType` is suboptimal, it looks like a function type and that's even harder to grok when you actually inspect a function type. I haven't yet thought of a good alternative presentation though, suggestions welcome.

I'm going to think about tests for this, some refactoring would make tests easier to write but that would also make review harder. So I went ahead and pushed what's here for now.