### PR TITLE
Make project config part of EnsimeLauncher's state

### DIFF
--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -1,3 +1,8 @@
+import os
+
+BOOTSTRAPS_ROOT = os.path.join(os.environ['HOME'], '.config/ensime-vim/')
+"""Default directory where ENSIME server bootstrap projects will be created."""
+
 gconfig = {
     "ensime_server": "ws://127.0.0.1:{}/jerky",
     "localhost": "http://127.0.0.1:{}/{}",

--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -4,19 +4,19 @@ gconfig = {
 }
 
 feedback = {
-    "analyzer_ready": "Ensime analyzer is ready",
+    "analyzer_ready": "Analyzer is ready",
     "displayed_type": "The type {} has been displayed",
     "failed_refactoring":
         "The refactoring could not be applied (more info at logs)",
-    "full_types_enabled_on": "[ensime] Qualified type display enabled",
-    "full_types_enabled_off": "[ensime] Qualified type display disabled",
-    "indexer_ready": "Ensime indexer is ready",
+    "full_types_enabled_on": "Qualified type display enabled",
+    "full_types_enabled_off": "Qualified type display disabled",
+    "indexer_ready": "Indexer is ready",
     "manual_doc": "Go to {}",
     "missing_debug_class": "You must specify a class to debug",
     "module_missing": "{} missing: do a `pip install {}` and restart vim",
     "notify_break": "Execution breaked at {} {}",
     "spawned_browser": "Opened tab {}",
-    "start_message": "Ensime server has been started...",
+    "start_message": "Server has been started...",
     "typechecking": "Typechecking...",
     "unhandled_response": "Response {} has not been handled",
     "unknown_symbol": "Symbol not found",

--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -11,6 +11,7 @@ feedback = {
     "full_types_enabled_on": "Qualified type display enabled",
     "full_types_enabled_off": "Qualified type display disabled",
     "indexer_ready": "Indexer is ready",
+    "invalid_java": "Java not found or not executable, verify :java-home in your .ensime config",
     "manual_doc": "Go to {}",
     "missing_debug_class": "You must specify a class to debug",
     "module_missing": "{} missing: do a `pip install {}` and restart vim",

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -54,7 +54,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
             self.vim_command("set_updatetime")
             self.vim_command("set_ensime_completion")
             self.vim.command("autocmd FileType package_info nnoremap <buffer> <Space> :call EnPackageDecl()<CR>")
-            self.vim.command("autocmd FileType package_info  setlocal splitright")
+            self.vim.command("autocmd FileType package_info setlocal splitright")
             super(EnsimeClient, self).__init__()
 
         def setup_logger_and_paths():
@@ -67,7 +67,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
             if not osp.isdir(self.ensime_cache):
                 try:
                     os.mkdir(self.ensime_cache)
-                except OSError as exception:
+                except OSError:
                     self.log_dir = "/tmp/"
             self.log_file = os.path.join(self.log_dir, "ensime-vim.log")
             with open(self.log_file, "w") as f:
@@ -375,7 +375,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
 
     def message(self, key):
         """Display a message already defined in `feedback`."""
-        msg = feedback[key]
+        msg = '[ensime] ' + feedback[key]
         self.raw_message(msg)
 
     def register_responses_handlers(self):
@@ -568,7 +568,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
                 try:
                     if webbrowser.open(url):
                         self.log("opened {}".format(url))
-                except webbrowser.Error, e:
+                except webbrowser.Error as e:
                     log_msg = "handle_string_response: webbrowser error: {}"
                     self.log(log_msg.format(e))
                     self.raw_message(feedback["manual_doc"].format(url))

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -4,7 +4,7 @@ import inspect
 import webbrowser
 
 # Ensime shared imports
-from ensime_shared.error import Error
+from ensime_shared.errors import InvalidJavaPathError
 from ensime_shared.util import catch, module_exists, Util
 from ensime_shared.launcher import EnsimeLauncher
 from ensime_shared.debugger import DebuggerClient
@@ -141,7 +141,6 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
         if not module_exists("sexpdata"):
             self.tell_module_missing("sexpdata")
 
-
     def log(self, what):
         """Log `what` in a file at the .ensime_cache folder or /tmp."""
         with open(self.log_file, "a") as f:
@@ -205,7 +204,12 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
                     if not quiet:
                         self.message("warn_classpath")
                     return False
-                self.ensime = self.launcher.launch()
+
+                try:
+                    self.ensime = self.launcher.launch()
+                except InvalidJavaPathError:
+                    self.message('invalid_java')  # TODO: also disable plugin
+
             return bool(self.ensime)
 
         def ready_to_connect():

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -198,15 +198,14 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
             if not self.ensime:
                 called_by = inspect.stack()[4][3]
                 self.log(str(inspect.stack()))
-                self.log("setup({}, {}) called by {}()"
+                self.log("setup(quiet={}, create_classpath={}) called by {}()"
                          .format(quiet, create_classpath, called_by))
-                no_classpath = self.launcher.no_classpath_file(
-                    self.config_path)
+                no_classpath = self.launcher.no_classpath_file()
                 if not create_classpath and no_classpath:
                     if not quiet:
                         self.message("warn_classpath")
                     return False
-                self.ensime = self.launcher.launch(self.config_path)
+                self.ensime = self.launcher.launch()
             return bool(self.ensime)
 
         def ready_to_connect():
@@ -1028,7 +1027,6 @@ class Ensime(object):
         self.vim = vim
         # Map ensime configs to a ensime clients
         self.clients = {}
-        self.launcher = EnsimeLauncher(vim)
         self.init_integrations()
 
     def init_integrations(self):
@@ -1095,7 +1093,8 @@ class Ensime(object):
         if abs_path in self.clients:
             client = self.clients[abs_path]
         elif create_client:
-            client = EnsimeClient(self.vim, self.launcher, config_path)
+            launcher = EnsimeLauncher(self.vim, config_path)
+            client = EnsimeClient(self.vim, launcher, config_path)
             if client.setup(quiet=quiet, create_classpath=create_classpath):
                 self.clients[abs_path] = client
         return client

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -200,7 +200,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, object):
                 self.log(str(inspect.stack()))
                 self.log("setup(quiet={}, create_classpath={}) called by {}()"
                          .format(quiet, create_classpath, called_by))
-                no_classpath = self.launcher.no_classpath_file()
+                no_classpath = not os.path.exists(self.launcher.classpath_file)
                 if not create_classpath and no_classpath:
                     if not quiet:
                         self.message("warn_classpath")

--- a/ensime_shared/errors.py
+++ b/ensime_shared/errors.py
@@ -1,9 +1,18 @@
 import os
 
 
-class Error:
-    """Represents an Error in the ensime-vim plugin."""
+class InvalidJavaPathError(OSError):
+    """Raised when ensime-vim cannot find a valid Java executable."""
 
+    def __init__(self, errno, msg, filename, *args):
+        super(InvalidJavaPathError, self).__init__(errno, msg, filename, *args)
+
+
+class Error(object):
+    """Represents an error in source code reported by ENSIME."""
+
+    # l, c, e are line, (beginning) column and end (column)
+    # TODO: docstring and rename these bad, lint-failing params :-P
     def __init__(self, path, message, l, c, e):
         self.path = os.path.abspath(path)
         self.message = message

--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -11,6 +11,7 @@ from string import Template
 
 import sexpdata
 
+from ensime_shared.config import BOOTSTRAPS_ROOT
 from ensime_shared.errors import InvalidJavaPathError
 from ensime_shared.util import Util, catch
 
@@ -52,21 +53,12 @@ class EnsimeProcess(object):
     def http_port(self):
         return int(Util.read_file(os.path.join(self.cache_dir, "http")))
 
-join = os.path.join
-home = os.environ["HOME"]
-
-# Use a new path that is clearer and more user-friendly
-_default_base_dir = join(home, ".config/ensime-vim/")
-_old_base_dir = join(home, ".config/classpath_project_ensime")
-if os.path.isdir(_old_base_dir):
-    shutil.move(_old_base_dir, _default_base_dir)
-
 
 class EnsimeLauncher(object):
     ENSIME_VERSION = '1.0.0'
     SBT_VERSION = '0.13.11'
 
-    def __init__(self, vim, config_path, base_dir=_default_base_dir):
+    def __init__(self, vim, config_path, base_dir=BOOTSTRAPS_ROOT):
         self.vim = vim
         self._config_path = os.path.abspath(config_path)
         self.config = self.parse_config(self._config_path)
@@ -74,6 +66,7 @@ class EnsimeLauncher(object):
         self.classpath_file = os.path.join(self.base_dir,
                                            self.config['scala-version'],
                                            'classpath')
+        self._migrate_legacy_bootstrap_location()
 
     def launch(self):
         cache_dir = self.config['cache-dir'],
@@ -296,3 +289,11 @@ saveClasspathTask := {
             success = True
 
         return success
+
+    @staticmethod
+    def _migrate_legacy_bootstrap_location():
+        """Moves an old ENSIME installer root to tidier location."""
+        home = os.environ['HOME']
+        old_base_dir = os.path.join(home, '.config/classpath_project_ensime')
+        if os.path.isdir(old_base_dir):
+            shutil.move(old_base_dir, BOOTSTRAPS_ROOT)

--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -59,14 +59,14 @@ if os.path.isdir(_old_base_dir):
 
 
 class EnsimeLauncher(object):
+    ENSIME_VERSION = '1.0.0'
+    SBT_VERSION = '0.13.11'
 
     def __init__(self, vim, config_path, base_dir=_default_base_dir):
         self.vim = vim
         self._config_path = os.path.abspath(config_path)
         self.config = self.parse_config(self._config_path)
         self.base_dir = os.path.abspath(base_dir)
-        self.ensime_version = "1.0.0"
-        self.sbt_version = "0.13.11"
         self.classpath_file = os.path.join(self.base_dir,
                                            self.config['scala-version'],
                                            'classpath')
@@ -135,7 +135,7 @@ class EnsimeLauncher(object):
             self.build_sbt())
         Util.write_file(
             os.path.join(project_dir, "project", "build.properties"),
-            "sbt.version={}".format(self.sbt_version))
+            "sbt.version={}".format(self.SBT_VERSION))
         Util.write_file(
             os.path.join(project_dir, "project", "plugins.sbt"),
             """addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M11")""")
@@ -216,7 +216,7 @@ saveClasspathTask := {
 }"""
         replace = {
             "scala_version": self.config['scala-version'],
-            "version": self.ensime_version,
+            "version": self.ENSIME_VERSION,
             "classpath_file": self.classpath_file,
         }
         for k in replace.keys():

--- a/ensime_shared/spec/features/conf_parse_steps.py
+++ b/ensime_shared/spec/features/conf_parse_steps.py
@@ -11,7 +11,6 @@ Failure = "Failure"
 
 @step('The config (?P<conf_path>resources/\w+.conf)')
 def existing_config(step, conf_path):
-    world.launcher = EnsimeLauncher(TestVim())
     world.config_path = path.abspath(testDir + "/" + conf_path)
 
 
@@ -19,7 +18,7 @@ def existing_config(step, conf_path):
 def load_config(step):
     c = None
     try:
-        c = world.launcher.parse_conf(world.config_path)
+        c = EnsimeLauncher.parse_config(world.config_path)
     except:
         c = Failure
     world.conf = c

--- a/ensime_shared/typecheck.py
+++ b/ensime_shared/typecheck.py
@@ -1,6 +1,6 @@
 import os
 import json
-from ensime_shared.error import Error
+from ensime_shared.errors import Error
 from ensime_shared.config import commands
 
 


### PR DESCRIPTION
This is several incremental refactoring steps that center around making the parsed `.ensime` part of an `EnsimeLauncher` instance's state, which I think makes logical design sense and you'll see that it reduces a lot of repetitive code and redundant method arguments getting passed around. This makes the class's interface simpler which IMO makes the plugin initialization and classpath bootstrap processes somewhat easier to understand.

There are several independently-coherent commits, it is probably easier to first review them one-by-one.

I'm going to try to add some tests here and thus I might rebase to make sure tests passed before these changes with no unexpected behavior changing along the way. But again, like #288, the code often isn't factored to make testability easy yet, so I might lose steam to finish that right now. Went ahead and opened a PR to make others aware there is some WIP in this area, up to you whether we wait on tests to merge.