### PR TITLE
Rename :EnClasspath to :EnInstall

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -155,8 +155,8 @@ function! ensime#com_en_debug_start(args, range) abort
     return s:call_plugin('com_en_debug_start', [a:args, a:range])
 endfunction
 
-function! ensime#com_en_classpath(args, range) abort
-    return s:call_plugin('com_en_classpath', [a:args, a:range])
+function! ensime#com_en_install(args, range) abort
+    return s:call_plugin('com_en_install', [a:args, a:range])
 endfunction
 
 function! ensime#com_en_debug_continue(args, range) abort

--- a/doc/ensime.txt
+++ b/doc/ensime.txt
@@ -98,7 +98,7 @@ Bootstrap ENSIME~
 
 The first time you use ensime-vim (per Scala version), it will "bootstrap" the
 ENSIME server installation for you--when opening a Scala file you will be
-prompted to run |:EnClasspath|. Do that and give it a minute or two to run.
+prompted to run |:EnInstall|. Do that and give it a minute or two to run.
 
 After this, you should see reports in Vim's message area that ENSIME is coming
 up, and the indexer and analyzer are ready. You're ready to go! Compile your
@@ -115,8 +115,8 @@ All commands are buffer-local, unless otherwise stated. This means you must
 edit a Scala file (Java coming soon...) in order for the commands to be
 available.
 
-                                                                *:EnClasspath*
-:EnClasspath
+                                                                  *:EnInstall*
+:EnInstall
 
     Bootstraps installation of the ENSIME server and starts it. Generally only
     needed on your first-time setup, or once per Scala version if you start
@@ -466,7 +466,7 @@ To trigger an update of ENSIME server, nuke the bootstrap project: >
 
     $ rm -rf ~/.config/ensime-vim/<your Scala version>
 
-Restart Vim and run |:EnClasspath|.
+Restart Vim and run |:EnInstall|.
 
 If you're debugging an issue or working on implementing a new feature, you'll
 find the logs useful -- relative to your project, check: >

--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -21,12 +21,13 @@ feedback = {
     "missing_debug_class": "You must specify a class to debug",
     "module_missing": "{} missing: do a `pip install {}` and restart vim",
     "notify_break": "Execution breaked at {} {}",
+    "prompt_server_install":
+        "Please run :EnInstall to install the ENSIME server for Scala {scala_version}",
     "spawned_browser": "Opened tab {}",
     "start_message": "Server has been started...",
     "typechecking": "Typechecking...",
     "unhandled_response": "Response {} has not been handled",
     "unknown_symbol": "Symbol not found",
-    "warn_classpath": "Execute :EnClasspath to set a classpath",
 }
 
 commands = {

--- a/plugin/ensime.vim
+++ b/plugin/ensime.vim
@@ -12,7 +12,7 @@ augroup ensime
     autocmd CursorMoved *.scala call ensime#au_cursor_moved(expand("<afile>"))
 augroup END
 
-command! -nargs=* -range EnClasspath call ensime#com_en_classpath([<f-args>], '')
+command! -nargs=* -range EnInstall call ensime#com_en_install([<f-args>], '')
 command! -nargs=* -range EnNoTeardown call ensime#com_en_no_teardown([<f-args>], '')
 command! -nargs=* -range EnTypeCheck call ensime#com_en_type_check([<f-args>], '')
 command! -nargs=* -range EnType call ensime#com_en_type([<f-args>], '')

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -104,9 +104,9 @@ class NeovimEnsime(Ensime):
     def com_en_debug_start(self, *args, **kwargs):
         super(NeovimEnsime, self).com_en_debug_start(*args, **kwargs)
 
-    @neovim.command('EnClasspath', **command_params)
-    def com_en_classpath(self, *args, **kwargs):
-        super(NeovimEnsime, self).com_en_classpath(*args, **kwargs)
+    @neovim.command('EnInstall', **command_params)
+    def com_en_install(self, *args, **kwargs):
+        super(NeovimEnsime, self).com_en_install(*args, **kwargs)
 
     @neovim.command('EnShowPackage', **command_params)
     def com_en_package_inspect(self, *args, **kwargs):


### PR DESCRIPTION
As per #303, this should hopefully be a lot less puzzling for a user’s first encounter with ensime-vim—the server classpath bootstrapping process is an implementation detail they shouldn’t have to understand beyond "install the ENSIME server, please".