### PR TITLE
Fix setting-exists check. Fixes #315

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -875,7 +875,7 @@ class Ensime(object):
 
     def get_setting(self, key, default):
         gkey = "g:ensime_{}".format(key)
-        key_exists = self.vim.eval("exists('{}')".format(gkey)) 
+        key_exists = int(self.vim.eval("exists('{}')".format(gkey))) 
         return self.vim.eval(gkey) if key_exists else default
 
     def init_integrations(self):


### PR DESCRIPTION
The check was always returning `True` 'cause `vim.eval()` returns a string if the expression evals to a number and `bool('0')` is True