### PR TITLE
Improve portability with standard library functions

### DIFF
--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -105,7 +105,7 @@ class EnsimeLauncher(object):
         Util.mkdir_p(cache_dir)
         log_path = os.path.join(cache_dir, "server.log")
         log = open(log_path, "w")
-        null = open("/dev/null", "r")
+        null = open(os.devnull, "r")
         java = os.path.join(self.config['java-home'], 'bin', 'java')
 
         if not os.path.exists(java):
@@ -128,6 +128,7 @@ class EnsimeLauncher(object):
 
         def on_stop():
             log.close()
+            null.close()
             with catch(Exception, lambda e: None):
                 os.remove(pid_path)
 


### PR DESCRIPTION
This is a pretty small change, some sundry things I noticed while trolling through the source. It got me started working on #294 since that's what `fetch_runtime_paths` is used for, so I was planning to package them up in a pull request together, but that's actually turning out to be a can of worms that touches the plugin core so I'm going to want to keep that review as focused as possible.

I don't know how close we are to running on Windows, but these were a couple of things that were easily improved by using the standard library. As the commit message says:

The `tempfile` module is Windows-friendly and will give us a secure temp directory, with permissions restricted to the user.

`os.path.expanduser` again supports Windows alternate idioms of `$HOME`.

Also, we should try to clean up our temp dir in teardown.