### PR TITLE
Use a proper logger

### DIFF
--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -17,9 +17,9 @@ gconfig = {
     "localhost": "http://127.0.0.1:{}/{}",
 }
 
+# Messages for user feedback, possible l10n fodder. Please keep alphabetized.
 feedback = {
     "analyzer_ready": "Analyzer is ready",
-    "displayed_type": "The type %s has been displayed",
     "failed_refactoring": "The refactoring could not be applied (more info at logs)",
     "full_types_enabled_off": "Qualified type display disabled",
     "full_types_enabled_on": "Qualified type display enabled",
@@ -36,7 +36,6 @@ feedback = {
     "spawned_browser": "Opened tab {}",
     "start_message": "Server has been started...",
     "typechecking": "Typechecking...",
-    "unhandled_response": "Response has not been handled: %s",
     "unknown_symbol": "Symbol not found",
 }
 

--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -10,6 +10,8 @@ from ensime_shared.util import Util
 BOOTSTRAPS_ROOT = os.path.join(os.environ['HOME'], '.config/ensime-vim/')
 """Default directory where ENSIME server bootstrap projects will be created."""
 
+LOG_FORMAT = '%(levelname)-8s <%(asctime)s> (%(filename)s:%(lineno)d) - %(message)s'
+
 gconfig = {
     "ensime_server": "ws://127.0.0.1:{}/jerky",
     "localhost": "http://127.0.0.1:{}/{}",
@@ -17,7 +19,7 @@ gconfig = {
 
 feedback = {
     "analyzer_ready": "Analyzer is ready",
-    "displayed_type": "The type {} has been displayed",
+    "displayed_type": "The type %s has been displayed",
     "failed_refactoring": "The refactoring could not be applied (more info at logs)",
     "full_types_enabled_off": "Qualified type display disabled",
     "full_types_enabled_on": "Qualified type display enabled",
@@ -34,7 +36,7 @@ feedback = {
     "spawned_browser": "Opened tab {}",
     "start_message": "Server has been started...",
     "typechecking": "Typechecking...",
-    "unhandled_response": "Response {} has not been handled",
+    "unhandled_response": "Response has not been handled: %s",
     "unknown_symbol": "Symbol not found",
 }
 

--- a/ensime_shared/debugger.py
+++ b/ensime_shared/debugger.py
@@ -29,7 +29,7 @@ class DebuggerClient(object):
 
 # API Call Build/Send
     def debug_set_break(self, args, range=None):
-        self.log("debug_set_break: in")
+        self.log.debug('debug_set_break: in')
         req = {"line": self.cursor()[0],
                "maxResults": 10,
                "typehint": "DebugSetBreakReq",
@@ -37,11 +37,11 @@ class DebuggerClient(object):
         self.send_request(req)
 
     def debug_clear_breaks(self, args, range=None):
-        self.log("debug_clear_breaks: in")
+        self.log.debug('debug_clear_breaks: in')
         self.send_request({"typehint": "DebugClearAllBreaksReq"})
 
     def debug_start(self, args, range=None):
-        self.log("debug_start: in")
+        self.log.debug('debug_start: in')
         if len(args) > 1:
             self.send_request({
                 "typehint": "DebugAttachReq",
@@ -54,13 +54,13 @@ class DebuggerClient(object):
                 "port": "5005"})
 
     def debug_continue(self, args, range=None):
-        self.log("debug_continue: in")
+        self.log.debug('debug_continue: in')
         self.send_request({
             "typehint": "DebugContinueReq",
             "threadId": self.debug_thread_id})
 
     def debug_backtrace(self, args, range=None):
-        self.log("debug_backtrace: in")
+        self.log.debug('debug_backtrace: in')
         self.send_request({
             "typehint": "DebugBacktraceReq",
             "threadId": self.debug_thread_id,

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -17,7 +17,7 @@ from .errors import InvalidJavaPathError
 from .launcher import EnsimeLauncher
 from .protocol import ProtocolHandler, ProtocolHandlerV1, ProtocolHandlerV2
 from .typecheck import TypecheckHandler
-from .util import catch, module_exists, Util
+from .util import catch, module_exists, Pretty, Util
 
 # Queue depends on python version
 if sys.version_info > (3, 0):
@@ -275,7 +275,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
         self.log.debug('send: in')
         if self.running and self.ws:
             with catch(Exception, reconnect):  # FIXME: what Exception??
-                self.log.debug('send: %s', msg)
+                self.log.debug('send: sending JSON on WebSocket')
                 self.ws.send(msg + "\n")
 
     def connect_ensime_server(self):
@@ -711,7 +711,11 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
     def send_request(self, request):
         """Send a request to the server."""
         self.log.debug('send_request: in')
-        self.send(json.dumps({"callId": self.call_id, "req": request}))
+
+        message = {'callId': self.call_id, 'req': request}
+        self.log.debug('send_request: %s', Pretty(message))
+        self.send(json.dumps(message))
+
         call_id = self.call_id
         self.call_id += 1
         return call_id
@@ -845,7 +849,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
                 # Unqueing messages until we get suggestions
                 self.unqueue(timeout=self.completion_timeout, should_wait=True)
                 suggestions = self.suggestions or []
-                self.log.debug('complete_func: suggests in %s', suggestions)
+                self.log.debug('complete_func: suggestions in')
                 for m in suggestions:
                     result.append(m)
                 self.suggestions = None

--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -57,7 +57,7 @@ class EnsimeProcess(object):
 class EnsimeLauncher(object):
     ENSIME_V1 = '1.0.0'
     ENSIME_V2 = '2.0.0-SNAPSHOT'
-    SBT_VERSION = '0.13.11'
+    SBT_VERSION = '0.13.12'
 
     def __init__(self, vim, config_path, server_v2, base_dir=BOOTSTRAPS_ROOT):
         self.vim = vim

--- a/ensime_shared/typecheck.py
+++ b/ensime_shared/typecheck.py
@@ -21,7 +21,7 @@ class TypecheckHandler(object):
                 self.buffered_notes['notes'].append(note)
 
     def start_typechecking(self):
-        self.log("getting ready")
+        self.log.info('Readying typecheck...')
         self.currently_buffering_typechecks = True
         if self.currently_buffering_typechecks:
             self.buffered_notes = {
@@ -78,5 +78,5 @@ class TypecheckHandler(object):
                 matcher = commands["enerror_matcher"].format(l, c, e)
                 match = self.vim.eval(matcher)
                 add_match_msg = "adding match {} at line {} column {} error {}"
-                self.log(add_match_msg.format(match, l, c, e))
+                self.log.debug(add_match_msg.format(match, l, c, e))
                 self.matches.append(match)

--- a/ensime_shared/util.py
+++ b/ensime_shared/util.py
@@ -2,6 +2,7 @@
 
 import os
 from contextlib import contextmanager
+from pprint import pformat
 
 
 class Util:
@@ -56,3 +57,17 @@ def module_exists(module_name):
         __import__(module_name)
         res = True
     return res
+
+
+class Pretty(object):
+    """Wrapper to pretty-format object's string representation.
+
+    Reduces boilerplate for logging statements where we don't want to eagerly
+    :func:`pprint.pformat` when the logging level isn't enabled.
+    """
+
+    def __init__(self, data):
+        self._data = data
+
+    def __str__(self):
+        return '\n' + pformat(self._data)


### PR DESCRIPTION
This is a first pass at #297. It does not attempt to hide trace logging code with decorators, etc. yet, I'm punting on the question of adding a dependency or rolling our own for now.

This uses the standard library `logging` module to get rid of the hacky inefficiency of our own homegrown `log` function that re-opens a file handle on every single call. It also adds sensible leveled logging, putting our trace-level logging statements at `DEBUG` level and logging more quietly than that by default.

For now I've just used an environment variable, `ENSIME_VIM_DEBUG`, as a binary toggle between `INFO` and `DEBUG` logging levels. I could add a `g:ensime_debug` Vim variable, we could make it possible to specify where logging goes instead of being hardcoded to `.ensime_cache/ensime-vim.log`, etc., but initially I wanted to add minimal features, just leveled logging with an as-simple-as-possible toggle for the level. Open to feedback.

I'm already finding it helpful to have file and line number of log statements in the output, and the `logging` module's native ability to show exception backtraces in the log. Here's an example of some debug output:

```
DEBUG    <2016-07-28 17:04:03,109> (ensime.py:272) - send: in
DEBUG    <2016-07-28 17:04:03,109> (ensime.py:275) - send: {"callId": 0, "req": {"typehint": "ConnectionInfoReq"}}
DEBUG    <2016-07-28 17:04:04,126> (ensime.py:750) - unqueue: result received
{
  "callId": 0,
  "payload": {
    "typehint": "ConnectionInfo",
    "implementation": {
      "name": "ENSIME"
    },
    "version": "1.0"
  }
}
DEBUG    <2016-07-28 17:04:04,126> (protocol.py:48) - handle_incoming_response: in {u'implementation': {u'name': u'ENSIME'}, u'typehint': u'ConnectionInfo', u'version': u'1.0'}
WARNING  <2016-07-28 17:04:04,126> (protocol.py:61) - Response has not been handled: {u'implementation': {u'name': u'ENSIME'}, u'typehint': u'ConnectionInfo', u'version': u'1.0'}
DEBUG    <2016-07-28 17:04:05,145> (ensime.py:750) - unqueue: result received
{
  "payload": {
    "typehint": "IndexerReadyEvent"
  }
}
DEBUG    <2016-07-28 17:04:05,145> (protocol.py:48) - handle_incoming_response: in {u'typehint': u'IndexerReadyEvent'}
DEBUG    <2016-07-28 17:04:05,145> (ensime.py:386) - message: in
DEBUG    <2016-07-28 17:04:05,145> (ensime.py:387) - [ensime] Indexer is ready
DEBUG    <2016-07-28 17:04:07,177> (ensime.py:750) - unqueue: result received
{
  "payload": {
    "typehint": "SendBackgroundMessageEvent",
    "detail": "Initializing Analyzer. Please wait...",
    "code": 105
  }
}
DEBUG    <2016-07-28 17:04:07,177> (protocol.py:48) - handle_incoming_response: in {u'code': 105, u'typehint': u'SendBackgroundMessageEvent', u'detail': u'Initializing Analyzer. Please wait...'}
WARNING  <2016-07-28 17:04:07,177> (protocol.py:61) - Response has not been handled: {u'code': 105, u'typehint': u'SendBackgroundMessageEvent', u'detail': u'Initializing Analyzer. Please wait...'}
DEBUG    <2016-07-28 17:04:08,187> (ensime.py:750) - unqueue: result received
{
  "payload": {
    "typehint": "AnalyzerReadyEvent"
  }
}
DEBUG    <2016-07-28 17:04:08,187> (protocol.py:48) - handle_incoming_response: in {u'typehint': u'AnalyzerReadyEvent'}
DEBUG    <2016-07-28 17:04:08,187> (ensime.py:386) - message: in
DEBUG    <2016-07-28 17:04:08,187> (ensime.py:387) - [ensime] Analyzer is ready
DEBUG    <2016-07-28 17:04:08,187> (ensime.py:750) - unqueue: result received
{
  "payload": {
    "typehint": "FullTypeCheckCompleteEvent"
  }
}
DEBUG    <2016-07-28 17:04:08,187> (protocol.py:48) - handle_incoming_response: in {u'typehint': u'FullTypeCheckCompleteEvent'}
```