### PR TITLE
Fix opening symbol from Package Inspector in Vim

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -99,8 +99,8 @@ function! ensime#com_en_declaration_split(args, range) abort
     return s:call_plugin('com_en_declaration_split', [a:args, a:range])
 endfunction
 
-function! ensime#fun_en_package_decl(args, range) abort
-    return s:call_plugin('fun_en_package_decl', [a:args, a:range])
+function! ensime#fun_en_package_decl() abort
+    return s:call_plugin('fun_en_package_decl', [[], []])
 endfunction
 
 function! ensime#com_en_symbol_by_name(args, range) abort


### PR DESCRIPTION
The wrapper function declaration in Vimscript looks like this:

```vim
function! EnPackageDecl() abort
    return ensime#fun_en_package_decl()
endfunction
```

It calls the autoload function with no arguments, but the definition of that func had required parameters, so the calls failed with an error.

This is a trivial hotfix so I'll merge it straightaway.