### PR TITLE
Make StringResponse handler's roles more obvious

### DIFF
--- a/doc/ensime.txt
+++ b/doc/ensime.txt
@@ -143,15 +143,6 @@ available.
     works offline using cached doc jars. See |ensime-custom-browser| to
     customize the browser used if heuristics don't pick the one you prefer.
 
-                                                                   *:EnDocUri*
-:EnDocUri
-
-    Displays documentation URL for the symbol under the cursor.
->
-    TODO: seems broken for me, and like :EnSymbol I can't think of good use
-    cases to support exposing this as a command, perhaps a function.
-<
-
                                                              *:EnFormatSource*
 :EnFormatSource
 

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -588,7 +588,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
         """Browse doc of whatever at cursor."""
         self.log.debug('browse: in')
         self.call_options[self.call_id] = {"browse": True}
-        self.doc_uri(args, range=None)
+        self.send_at_position("DocUri", "point")
 
     def rename(self, new_name, range=None):
         """Request a rename to the server."""


### PR DESCRIPTION
This is an incremental refactoring in response to #330 and the discussion that spawned it: https://github.com/ensime/ensime-vim/pull/328#discussion_r72899574

This does not attempt to solve some broader design issues discussed in #330, it’s just a small localized change to separate the logic for the very different types of requests that `StringResponse` can be returned for, so it's more obvious that this handler has these different roles. This is in part to help factor out the direct usage of the editor to finish #328. I've made these private functions for now, they're not really handler functions for discrete ENSIME server response message types like the rest of the formal `ProtocolHandler` interface. They will might eventually fit logically somewhere else.

As I've mentioned elsewhere, I don't really understand the purpose of the `:EnDocUri` command, it used to print the documentation URL in Vim's message area—which I don't see as useful—but even that is broken on current master (the command actually causes an exception). My guess is that the intent was that it could be useful as a *function* instead of command, allowing users to do something custom with the URL as a function result. As-is I don't yet see how to cleanly change it to work that way, it would have to be made synchronous. So with this change, I have un-documented the command but left some implementation in place with a TODO (and it no longer causes an exception, just basically a no-op). I could just go all the way and completely remove the command and that handling code right now, WDYT?