### PR TITLE
Better server installation path

### DIFF
--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -65,9 +65,11 @@ class EnsimeLauncher(object):
         self.ensime_version = self.ENSIME_V2 if server_v2 else self.ENSIME_V1
         self._config_path = os.path.abspath(config_path)
         self.config = ProjectConfig(self._config_path)
+        self.scala_minor = self.config['scala-version'][:4]
         self.base_dir = os.path.abspath(base_dir)
         self.classpath_file = os.path.join(self.base_dir,
-                                           self.config['scala-version'],
+                                           self.scala_minor,
+                                           self.ensime_version,
                                            'classpath')
         self._migrate_legacy_bootstrap_location()
 
@@ -90,9 +92,8 @@ class EnsimeLauncher(object):
 
         # Allow override with a local development server jar, see:
         # http://ensime.github.io/contributing/#manual-qa-testing
-        scala_minor = self.config['scala-version'][:4]
         for x in os.listdir(self.base_dir):
-            if fnmatch.fnmatch(x, "ensime_" + scala_minor + "*-assembly.jar"):
+            if fnmatch.fnmatch(x, "ensime_" + self.scala_minor + "*-assembly.jar"):
                 classpath = os.path.join(self.base_dir, x) + ":" + classpath
 
         return classpath


### PR DESCRIPTION
The installation folder has now the pattern `{scala_minor}/{ensime_version}`.

Examples:

- `2.10/1.0.0`
- `2.11/2.0.0-SNAPSHOT`

It has two benefits over the previous folder name (Scala full version):

- Ensime plugin will not ask for `:EnInstall` for different
  Scala patch versions. Ex: (2.11.7 vs 2.11.8)
- Easy switch between Ensime Server V1 and V2