### PR TITLE
Fix regression in non-Syntastic typecheck error highlighting

### DIFF
--- a/ensime_shared/editor.py
+++ b/ensime_shared/editor.py
@@ -357,7 +357,7 @@ class Editor(object):
         """Renders "notes" reported by ENSIME, such as typecheck errors."""
 
         # TODO: this can probably be a cached property like isneovim
-        hassyntastic = bool(self._vim.eval('exists(":SyntasticCheck")'))
+        hassyntastic = bool(int(self._vim.eval('exists(":SyntasticCheck")')))
 
         if hassyntastic:
             self.__display_notes_with_syntastic(notes)
@@ -395,7 +395,7 @@ class Editor(object):
 
     def __display_notes(self, notes):
         current_file = self.path()
-        highlight_cmd = r"matchadd('EnErrorStyle', '\\%{}l\\%>{}c\\%<{}c')"
+        highlight_cmd = r"matchadd('EnErrorStyle', '\%{}l\%>{}c\%<{}c')"
 
         for note in notes:
             l = note['line']

--- a/ensime_shared/typecheck.py
+++ b/ensime_shared/typecheck.py
@@ -25,7 +25,9 @@ class TypecheckHandler(object):
 
         Calls editor to display/highlight line notes and clears notes buffer.
         """
+        self.log.debug('handle_typecheck_complete: in')
         if not self.currently_buffering_typechecks:
+            self.log.debug('Completed typecheck was not requested by user, not displaying notes')
             return
 
         self.editor.display_notes(self.buffered_notes)


### PR DESCRIPTION
Regression from #328 where I didn't properly cast Vim's string `'0'` result from the Syntastic feature detection to Boolean, and escaping was doubled when changing highlight match pattern to a Python raw string.

I believe this fixes the issue—the highlighting only works for me in GUI, not on console, but I *think* that's something with my setup or something that wasn't changed by #328 anyway. This feature is still kinda janky altogether, I made notes in #328 about the logic for the highlighting group customization seemingly not making sense, etc.

It'd be good to add a test or two but it would be a bit hairy to do, so I'll save that until the further `Editor` API improvements, and maybe we can give this feature a little love overall.

Closes #339. @gigiigig you might be happy with Syntastic now, but if you're able to try this with it disabled and confirm if it restores the behavior you had before, that'd be awesome.