### PR TITLE
Fix #357: Avoid two steps when jumping to decl

### DIFF
--- a/ensime_shared/client.py
+++ b/ensime_shared/client.py
@@ -316,7 +316,8 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
             self.editor.set_cursor(decl_pos['line'], 0)
         else:  # OffsetSourcePosition
             point = decl_pos["offset"]
-            self.editor.goto(point + 1)
+            row, col = self.editor.point2pos(point + 1)
+            self.editor.set_cursor(row, col)
 
     def get_position(self, row, col):
         """Get char position in all the text from row and column."""

--- a/ensime_shared/editor.py
+++ b/ensime_shared/editor.py
@@ -80,8 +80,17 @@ class Editor(object):
         return buf[:]
 
     def goto(self, offset):
-        """Go to a specific byte offset in the current buffer."""
+        """Go to a specific byte offset in the current buffer.
+
+        Operation is added to the jump list.
+        """
         self._vim.command('goto {}'.format(offset))
+
+    def point2pos(self, point):
+        """Converts a point or offset in a file to a (row, col) position."""
+        row = self._vim.eval('byte2line({})'.format(point))
+        col = self._vim.eval('{} - line2byte({})'.format(point, row))
+        return (int(row), int(col))
 
     def menu(self, prompt, choices):
         """Presents a selection menu and returns the user's choice.
@@ -216,7 +225,10 @@ class Editor(object):
         return self._vim.current.window.cursor
 
     def set_cursor(self, row, col):
-        """Set cursor position to given row and column in the current window."""
+        """Set cursor position to given row and column in the current window.
+
+        Operation is not added to the jump list.
+        """
         self._vim.current.window.cursor = (row, col)
 
     # TODO: don't displace user's cursor; can something like ``getpos()`` do this?


### PR DESCRIPTION
The fix consists in using the internal vim machinery to translate a
point/offset to a position in terms of lines and columns. With this
information, we can use the `set_cursor` operation which is not added to
the jump list, unlike the `goto` operation that we were using before.

This commit also clarifies the effect of these operations in the
pertinent docs of every function.