### PR TITLE
Remove the last raw vim instance from EnsimeClient

### DIFF
--- a/ensime_shared/client.py
+++ b/ensime_shared/client.py
@@ -280,6 +280,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
                 from websocket import create_connection
                 # Use the default timeout (no timeout).
                 options = {"subprotocols": ["jerky"]} if server_v2 else {}
+                options['enable_multithread'] = True
                 self.log.debug("About to connect to %s with options %s",
                                self.ensime_server, options)
                 self.ws = create_connection(self.ensime_server, **options)

--- a/ensime_shared/client.py
+++ b/ensime_shared/client.py
@@ -48,7 +48,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
     which stores the a handler per response type.
     """
 
-    def __init__(self, editor, vim, launcher):  # noqa: C901 FIXME
+    def __init__(self, editor, launcher):  # noqa: C901 FIXME
         # Our use case of a logger per class instance with independent log files
         # requires a bunch of manual programmatic config :-/
         def setup_logger():
@@ -81,24 +81,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
             logger.info('Initializing project - %s', projectdir)
             return logger
 
-        def fetch_runtime_paths():
-            """Fetch all the runtime paths of ensime-vim plugin.
-
-            disable_plugin needs this to run on the main thread, hence the
-            eager execution from constructor.
-            """
-            runtimepath = self.vim.eval('&runtimepath')
-            plugin = "ensime-vim"
-            paths = []
-
-            for path in runtimepath.split(','):
-                if plugin in path:
-                    paths.append(os.path.expanduser(path))
-
-            return paths
-
         super(EnsimeClient, self).__init__()
-        self.vim = vim
         self.editor = editor
         self.launcher = launcher
 
@@ -128,11 +111,6 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
         self.toggle_teardown = True
         self.connection_attempts = 0
         self.tmp_diff_folder = tempfile.mkdtemp(prefix='ensime-vim-diffs')
-
-        # Set the runtime path here in case we need
-        # to disable the plugin. It needs to be done
-        # beforehand since vim.eval is not threadsafe
-        self.runtime_paths = fetch_runtime_paths()
 
         # By default, don't connect to server more than once
         self.number_try_connection = 1
@@ -167,9 +145,9 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
                         connection_alive = False  # noqa: F841
                     else:
                         if not self.number_try_connection:
-                            # Stop everything and disable plugin
+                            # Stop everything.
                             self.teardown()
-                            self.disable_plugin()
+                            self._display_ws_warning()
 
                 # WebSocket exception may happen
                 # FIXME: What Exception class? Don't catch Exception
@@ -224,26 +202,10 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
         msg = feedback["module_missing"]
         self.editor.raw_message(msg.format(name, name))
 
-    # TODO: this should be the Ensime class's responsibility, not EnsimeClient;
-    #       move (and eliminate self.vim) after fixing, see #294
-    def disable_plugin(self):
-        """Disable plugin temporarily, including also related plugins."""
-        self.log.debug('disable_plugin: in')
-
-        def threadsafe_vim(command):
-            """Threadsafe call if neovim, normal if vim."""
-            def normal_vim(e):
-                self.vim.command(command)
-            with catch(Exception, normal_vim):
-                self.vim.session.threadsafe_call(command)
-
-        for path in self.runtime_paths:
-            self.log.debug(path)
-            threadsafe_vim('set runtimepath-={}'.format(path))
-
+    def _display_ws_warning(self):
         warning = "A WS exception happened, 'ensime-vim' has been disabled. " +\
             "For more information, have a look at the logs in `.ensime_cache`"
-        threadsafe_vim('echo "{}"'.format(warning))
+        self.editor.raw_message(warning)
 
     def send(self, msg):
         """Send something to the ensime server."""
@@ -268,7 +230,7 @@ class EnsimeClient(TypecheckHandler, DebuggerClient, ProtocolHandler):
             if e:
                 self.log.error('connection error: %s', e, exc_info=True)
             self.shutdown_server()
-            self.disable_plugin()
+            self._display_ws_warning()
 
         if self.running and self.number_try_connection:
             self.number_try_connection -= 1

--- a/ensime_shared/editor.py
+++ b/ensime_shared/editor.py
@@ -9,7 +9,7 @@ class Editor(object):
 
     def __init__(self, driver):
         self._vim = driver
-        self._isneovim = bool(self._vim.eval("has('nvim')"))
+        self._isneovim = bool(int(self._vim.eval("has('nvim')")))
 
         # Old API
         self._errors = []   # Line error structs reported from ENSIME notes
@@ -302,10 +302,15 @@ class Editor(object):
 
     def raw_message(self, message, silent=False):
         """Display a message in the Vim status line."""
+        vim = self._vim
         cmd = 'echo "{}"'.format(message.replace('"', '\\"'))
         if silent:
             cmd = 'silent ' + cmd
-        self._vim.command(cmd)
+
+        if self.isneovim:
+            vim.async_call(vim.command, cmd)
+        else:
+            vim.command(cmd)
 
     def symbol_for_inspector_line(self, lineno):
         """Given a line number for the Package Inspector window, returns the

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -130,13 +130,14 @@ class Ensime(object):
             If used from a secondary thread, this may need to use threadsafe
             Vim calls where available -- see :meth:`Editor.raw_message`.
         """
-        for path in self.runtime_paths:
+        for path in self.runtime_paths():
             self._vim.command('set runtimepath-={}'.format(path))
 
-    @property
+    # Tried making this a @property, with and without memoization, and it made
+    # plugin initialization misbehave in Neovim (only). WTF.
     def runtime_paths(self):  # TODO: memoize
         """All the runtime paths of ensime-vim plugin files."""
-        runtimepath = self._vim.eval('&runtimepath')
+        runtimepath = self._vim.options['runtimepath']
         plugin = "ensime-vim"
         paths = []
 


### PR DESCRIPTION
Doing some refactoring, and here's one chunk that stood alone from larger changes.

`disable_plugin` doesn't really work (#294). We might not need it at all if upcoming changes handle problem scenarios better (reconnect to server, throw away client instance for a new one, restart server, etc.), but for now I moved it to `Ensime` with a todo. That's where it probably belongs anyway if fixed since `Ensime` represents the plugin itself, and if there are multiple clients (multiple projects in the Vim session) then they should all get shut down if the plugin is disabled. `Ensime` is currently the place to handle things like that.