### PR TITLE
Avoid scanning config dir that does not exist

### DIFF
--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -205,6 +205,8 @@ class AssemblyJar(LaunchStrategy):
         self.toolsjar = os.path.join(config['java-home'], 'lib', 'tools.jar')
 
     def isinstalled(self):
+        if not os.path.exists(self.base_dir):
+            return False
         scala_minor = self.config['scala-version'][:4]
         for fname in os.listdir(self.base_dir):
             if fnmatch(fname, "ensime_" + scala_minor + "*-assembly.jar"):

--- a/test/test_launcher.py
+++ b/test/test_launcher.py
@@ -41,6 +41,11 @@ class TestAssemblyJarStrategy:
         self.assemblyjar(strategy)
         assert strategy.isinstalled()
 
+    def test_isinstalled_when_base_dir_does_not_exist(self, tmpdir):
+        bogus = tmpdir / 'nonexisting'
+        strategy = AssemblyJar(config('test-bootstrap.conf'), base_dir=bogus.strpath)
+        assert not strategy.isinstalled()
+
     def test_launch_constructs_classpath(self, strategy, assemblyjar):
         assert strategy.isinstalled()
         with patch.object(strategy, '_start_process', autospec=True) as start:


### PR DESCRIPTION
Since #354 it was possible that we checked for the presence of an assembly jar in the config directory before ever creating that dir ourselves.

This should fix #363.