### PR TITLE
Remove old undocumented/untested extension API

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -27,14 +27,6 @@ function! ensime#is_scala_file() abort
     return s:call_plugin('is_scala_file', [])
 endfunction
 
-function! ensime#on_receive(name, callback) abort
-    return s:call_plugin('on_receive', [a:name, a:callback])
-endfunction
-
-function! ensime#send_request(request) abort
-    return s:call_plugin('send_request', [a:request])
-endfunction
-
 function! ensime#fun_en_complete_func(findstart, base) abort
     return s:call_plugin('fun_en_complete_func', [a:findstart, a:base])
 endfunction

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -272,11 +272,3 @@ class Ensime(object):
             # Invoked by vim
             findstart = findstart_and_base
         return client.complete_func(findstart, base)
-
-    @execute_with_client()
-    def on_receive(self, client, name, callback):
-        client.on_receive(name, callback)
-
-    @execute_with_client()
-    def send_request(self, client, request):
-        client.send_request(request)


### PR DESCRIPTION
More housekeeping.

This was added way back in #92 as a riff on #64. I like the idea, but since it's untested and virtually undocumented it has faded into obscurity even for ensime-vim core developers, I believe. It has never really been exposed in the modern incarnation of our Neovim rplugin and I highly doubt anyone is using it.

We're doing a lot of major refactoring and any dead code like this only gets in the way. I have some new ideas for a plugin API that could be a spiritual successor to this, and I'd like to bring such an API back with documentation, tests, and ideally dogfooding that proves the design and keeps it working.