### PR TITLE
Fail fast if our python dependencies aren't installed – closes #236

### DIFF
--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -29,7 +29,6 @@ feedback = {
     "invalid_java": "Java not found or not executable, verify :java-home in your .ensime config",
     "manual_doc": "Go to {}",
     "missing_debug_class": "You must specify a class to debug",
-    "module_missing": "{} missing: do a `pip install {}` and restart vim",
     "notify_break": "Execution paused at breakpoint line {} in {}",
     "package_inspect_current": "Using currently focused package...",
     "prompt_server_install":

--- a/ensime_shared/util.py
+++ b/ensime_shared/util.py
@@ -51,14 +51,6 @@ def catch(exception, handler=lambda e: None):
         handler(str(e))
 
 
-def module_exists(module_name):
-    res = False
-    with catch(ImportError):
-        __import__(module_name)
-        res = True
-    return res
-
-
 class Pretty(object):
     """Wrapper to pretty-format object's string representation.
 


### PR DESCRIPTION
We were jumping through some weird hoops to avoid early imports that might have prevented the plugin from loading entirely, with bad error messaging. But that resulted in the plugin getting a lot further into execution than it should (including starting the server), since it can't do anything useful without these deps installed.

I came up with a way to validate the deps before our Python modules load, so now we can import normally in our code. This works in Vim and Neovim, prompting the user with a message when starting up if a dependency is missing.

There is one edge case: if a Neovim user has already used ensime-vim before and has generated the rplugin manifest, Neovim is going to load it. In the case that they've inadvertently removed one of the deps or their Python environment changed or whatever, they'll first be shown the message at startup as usual about missing deps (pausing for them to hit Enter), but then Neovim will start reporting errors about the autocmd handlers not working.

I think this is acceptable, the user still gets the helpful error message first and just needs to quit the editor and fix it. Plus it's a fairly unusual case. What do you think? I can't see a way to avoid this except to have every function in the rplugin do an `ImportError` check before calling `super`, or something gross like that. This is an unfortunate consequence of the whole `:UpdateRemotePlugins` cached manifest system.