### PR TITLE
Work around a startup error on Vim < 7.4

### DIFF
--- a/plugin/ensime.vim
+++ b/plugin/ensime.vim
@@ -21,15 +21,28 @@ endif
 function! s:DependenciesValid() abort
     python <<PY
 import vim
+
+# TODO: officially drop Vim < 7.4 support, inform users and don't load plugin
+VIM74 = hasattr(vim, 'vars')
+
 try:
     import sexpdata
     import websocket
 
-    vim.vars['ensime_deps_valid'] = True
+    if VIM74:
+        vim.vars['ensime_deps_valid'] = True
+    else:
+        vim.command('let g:ensime_deps_valid = 1')
+
     del sexpdata # Clean up the shared interpreter namespace
     del websocket
 except ImportError:
-    vim.vars['ensime_deps_valid'] = False
+    if VIM74:
+        vim.vars['ensime_deps_valid'] = False
+    else:
+        vim.command('let g:ensime_deps_valid = 0')
+
+del VIM74
 PY
 
     return g:ensime_deps_valid


### PR DESCRIPTION
Closes #369, refs #368 (1b32e85f)

Yeah, I could have left only the `vim.command` version of the code here and had compatibility with old and new, but there are other uses of Vim 7.4+ Python API in our code and this change does not attempt to fix all of them now. This just avoids a particularly poor failure mode during Vim startup.

I think we ought to officially make versions this old unsupported: detect the version and gracefully reject loading the plugin, informing the user. Serious day-to-day work on Scala projects where you'd want IDE features suggests a workstation-class environment IMO, so ensime-vim ought to be free to make assumptions accordingly. ensime-emacs is rather stringent about its requirements. Ubuntu 12.04 (as in #369) goes end-of-life in about 3 months, so it's barely server-class anymore. A possible policy could be to support the last two Vim minor versions (i.e. 8.0 and 7.4). We can discuss this more on a new issue.