### PR TITLE
Escape path when calling `pyfile`

### DIFF
--- a/autoload/ensime.vim
+++ b/autoload/ensime.vim
@@ -1,5 +1,5 @@
 if !has('nvim')
-    execute 'silent! pyfile' expand('<sfile>:p').'.py'
+    execute 'silent! pyfile' fnameescape(expand('<sfile>:p').'.py')
     execute ':redraw!'
 endif
 


### PR DESCRIPTION
Addresses: https://github.com/ensime/ensime-vim/issues/372#issuecomment-277273987