### PR TITLE
Use typehint instead of isCallable to format completion. Closes #313

### DIFF
--- a/ensime_shared/symbol_format.py
+++ b/ensime_shared/symbol_format.py
@@ -20,10 +20,14 @@ def completion_to_suggest(completion):
     return res
 
 
+def is_basic_type(completion):
+    return completion["typeInfo"]["typehint"] == "BasicTypeInfo"
+
+
 def formatted_completion_sig(completion):
     """Regenerate signature for methods. Return just the name otherwise"""
     f_result = completion["name"]
-    if not completion["isCallable"]:
+    if is_basic_type(completion):
         # It's a raw type
         return f_result
     elif len(completion["typeInfo"]["paramSections"]) == 0:
@@ -38,7 +42,7 @@ def formatted_completion_sig(completion):
 def formatted_completion_type(completion):
     """Use result type for methods. Return just the member type otherwise"""
     t_info = completion["typeInfo"]
-    return t_info["name"] if not completion["isCallable"] else t_info["resultType"]["name"]
+    return t_info["name"] if is_basic_type(completion) else t_info["resultType"]["name"]
 
 
 def formatted_param_section(section):

--- a/test/features/suggestion_format.feature
+++ b/test/features/suggestion_format.feature
@@ -61,19 +61,19 @@ Feature: Format a Completion Suggestion
     Then We get the format (implicit a: A, b: B)
 
   Scenario Outline: Format completion type
-    Given Completion with isCallable <is_callable>
+    Given Completion with typehint <typehint>
     And TypeInfo with type <ctype>
     And TypeInfo with resultType <crtype>
     When We format the completion type
     Then We get the format <ctype_format>
 
   Examples:
-    | is_callable | ctype     | crtype        | ctype_format  |
-    | False       | TheType   | NotUsed       | TheType       |
-    | True        | ACallable | TheResultType | TheResultType |
+    | typehint      | ctype     | crtype        | ctype_format  |
+    | BasicTypeInfo | TheType   | NotUsed       | TheType       |
+    | ArrowTypeInfo | ACallable | TheResultType | TheResultType |
 
   Scenario: Format non-callable completion signature
-    Given Completion with isCallable False
+    Given Completion with typehint BasicTypeInfo
     And Name is nonCallable
     And Sections:
       | implicit | pname | ptype |
@@ -81,7 +81,7 @@ Feature: Format a Completion Suggestion
     Then We get the format nonCallable
 
   Scenario: Format non-params-callable completion signature
-    Given Completion with isCallable True
+    Given Completion with typehint ArrowTypeInfo
     And Name is nonParamsCallable
     And Sections:
       | implicit | pname | ptype |
@@ -89,7 +89,7 @@ Feature: Format a Completion Suggestion
     Then We get the format nonParamsCallable
 
   Scenario: Format callable completion signature
-    Given Completion with isCallable True
+    Given Completion with typehint ArrowTypeInfo
     And Name is theCallable
     And Sections:
       | implicit | pname | ptype |
@@ -100,10 +100,10 @@ Feature: Format a Completion Suggestion
 
   Scenario: Convert completions to suggestions
     Given We have the following completions:
-      | name              | is_callable | ctype        | crtype        | pname | ptype | implicit |
-      | nonCallable       | False       | SomeType     |               |       |       |          |
-      | nonParamsCallable | True        | OtherType    | TheResultType |       |       |          |
-      | theCallable       | True        | CallableType | TheResultType | a     | A     | False    |
+      | name              | typehint      | ctype        | crtype        | pname | ptype | implicit |
+      | nonCallable       | BasicTypeInfo | SomeType     |               |       |       |          |
+      | nonParamsCallable | ArrowTypeInfo | OtherType    | TheResultType |       |       |          |
+      | theCallable       | ArrowTypeInfo | CallableType | TheResultType | a     | A     | False    |
     When We convert completions to suggestions
     Then We get the following suggestions:
       | word              | abbr              | menu          |

--- a/test/features/suggestion_format_steps.py
+++ b/test/features/suggestion_format_steps.py
@@ -55,9 +55,9 @@ def format_section(step):
     world.formatted = formatted_param_section(section)
 
 
-@step('Completion with isCallable (.+)')
-def given_completion_callable(step, is_callable):
-    world.is_callable = is_callable
+@step('Completion with typehint (.+)')
+def given_completion_callable(step, typehint):
+    world.typehint = typehint
 
 
 @step('TypeInfo with type (.+)')
@@ -73,9 +73,9 @@ def typeinfo_with_return_type(step, crtype):
 @step('We format the completion type')
 def format_completion_type(step):
     world.completion = {
-        "isCallable": world.is_callable == 'True',
         "typeInfo": {
             "name": world.ctype,
+            "typehint": world.typehint,
             "resultType": {"name": world.crtype}
         }
     }
@@ -103,8 +103,10 @@ def sections(step):
 def format_sig(step):
     completion = {
         "name": world.name,
-        "isCallable": world.is_callable == 'True',
-        "typeInfo": {"paramSections": world.sections}
+        "typeInfo": {
+            "typehint": world.typehint,
+            "paramSections": world.sections
+        }
     }
     world.formatted = formatted_completion_sig(completion)
 
@@ -112,8 +114,10 @@ def format_sig(step):
 def hash_to_completion(h):
     completion = {
         "name": h["name"],
-        "isCallable": h["is_callable"] == 'True',
-        "typeInfo": {"name": h["ctype"]}
+        "typeInfo": {
+            "typehint": h["typehint"],
+            "name": h["ctype"]
+        }
     }
 
     if h["crtype"]:


### PR DESCRIPTION
This is one of the issues preventing vim from using server 2.0