### PR TITLE
Honor selection when asking for type info. Closes #379

### DIFF
--- a/doc/ensime.txt
+++ b/doc/ensime.txt
@@ -174,7 +174,9 @@ available.
                                                                      *:EnType*
 :EnType
 
-    Displays type of the expression under the cursor.
+    Without parameters it displays type of the expression under the cursor.
+    If 'selection' parameter is included it displays the type of the expression
+    enclosed by the last active visual selection.
 
                                                                 *:EnTypeCheck*
 :EnTypeCheck
@@ -404,12 +406,14 @@ autocommands like this in a monolithic `vimrc`: >
 
     autocmd FileType scala,java
           \ nnoremap <buffer> <silent> <LocalLeader>t :EnType<CR> |
+          \ xnoremap <buffer> <silent> <LocalLeader>t :EnType selection<CR> |
           \ nnoremap <buffer> <silent> <LocalLeader>T :EnTypeCheck<CR>
 
 or the equivalent simple mappings in a `$MYVIMRUNTIME/after/ftplugin` file: >
 
     " ~/.vim/after/ftplugin/scala.vim
     nnoremap <buffer> <silent> <LocalLeader>t :EnType<CR>
+    xnoremap <buffer> <silent> <LocalLeader>t :EnType selection<CR>
     nnoremap <buffer> <silent> <LocalLeader>T :EnTypeCheck<CR>
 
 This is a matter of preference. The former may be easier for sharing common

--- a/ensime_shared/editor.py
+++ b/ensime_shared/editor.py
@@ -235,12 +235,19 @@ class Editor(object):
         self._vim.current.window.cursor = (row, col)
 
     # TODO: don't displace user's cursor; can something like ``getpos()`` do this?
-    def start_end_pos(self):
+    def word_under_cursor_pos(self):
         """Return start and end positions of the cursor respectively."""
         self._vim.command('normal e')
         end = self.cursor()
         self._vim.command('normal b')
         beg = self.cursor()
+        return beg, end
+
+    def selection_pos(self):
+        """Return start and end positions of the visual selection respectively."""
+        buff = self._vim.current.buffer
+        beg = buff.mark('<')
+        end = buff.mark('>')
         return beg, end
 
     def path(self):

--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -177,7 +177,7 @@ class Ensime(object):
 
     @execute_with_client()
     def com_en_type(self, client, args, range=None):
-        client.type(None)
+        client.type(args)
 
     @execute_with_client()
     def com_en_toggle_fulltype(self, client, args, range=None):


### PR DESCRIPTION
Fixes #379 by adding a new parameter to `EnType` command which can be used in mappings for applying the command to the visual selection instead of the word under the cursor.

Since there is no way to detect if a selection was active when in `command-mode` and `-range` is only useful line-wise, I had to introduce an optional argument to `:EnType` to know when to operate on the selection instead of on word under cursor. This new arg enables mappings like the following:

```VimL
  nnoremap <buffer> <silent> <Leader>st :EnType<CR>
  xnoremap <buffer> <silent> <Leader>st :EnType selection<CR>
```

Cheers.