### PR TITLE
Fix Windows Java classpath to launch the ensime server

### DIFF
--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -163,6 +163,13 @@ class LaunchStrategy:
         null = open(os.devnull, "r")
         java = os.path.join(self.config['java-home'], 'bin', 'java')
 
+        if(os.name == "nt"):
+            java += ".exe" #the java executable has the .exe extension in windows
+            # windows uses ';' instead of ':' for the classpath sep since ':' is reserved (C:\)
+            # for example  "c:\ensime.jar:c:\scala.jar"  =>  "c:\ensime.jar;c:\scala.jar"
+            # the following ".jar:" hack works because only jar's happen to be on the ensime classpath
+            classpath = classpath.replace(".jar:",".jar;")
+
         if not os.path.exists(java):
             raise InvalidJavaPathError(errno.ENOENT, 'No such file or directory', java)
         elif not os.access(java, os.X_OK):

--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -163,7 +163,7 @@ class LaunchStrategy:
         log_path = os.path.join(cache_dir, "server.log")
         log = open(log_path, "w")
         null = open(os.devnull, "r")
-        java = os.path.join(self.config['java-home'], 'bin', ('java','java.exe')[os.name == 'nt'] )
+        java = os.path.join(self.config['java-home'], 'bin', 'java' if os.name != 'nt' else 'java.exe')
 
         if not os.path.exists(java):
             raise InvalidJavaPathError(errno.ENOENT, 'No such file or directory', java)
@@ -171,7 +171,7 @@ class LaunchStrategy:
             raise InvalidJavaPathError(errno.EACCES, 'Permission denied', java)
 
         args = (
-            [java, "-cp", (':',';')[os.name == 'nt'].join(classpath)] +
+            [java, "-cp", (':' if os.name != 'nt' else ';').join(classpath)] +
             [a for a in java_flags if a] +
             ["-Densime.config={}".format(self.config.filepath),
              "org.ensime.server.Server"])

--- a/test/test_launcher.py
+++ b/test/test_launcher.py
@@ -53,7 +53,7 @@ class TestAssemblyJarStrategy:
 
         assert start.call_count == 1
         args, _kwargs = start.call_args
-        classpath = args[0].split(':')
+        classpath = args[0]
         assert classpath == [strategy.jar_path,
                              strategy.toolsjar,
                              ] + strategy.config['scala-compiler-jars']
@@ -87,7 +87,7 @@ class TestDotEnsimeStrategy:
 
         assert start.call_count == 1
         args, _kwargs = start.call_args
-        classpath = args[0].split(':')
+        classpath = args[0]
         assert classpath == strategy.classpath
 
     def test_launch_raises_when_not_installed(self, strategy):


### PR DESCRIPTION
This fixes two problems preventing use of ensime with Vim/GVIM for Windows.

1. Although `java-home` was set correctly, the java executable was not
found since windows uses a `.exe` for the java executable.
2. Windows uses `;` as a classpath separator instead of `:`.

Yea! Now I am running with Ensime in Vim on a Windows machine!

--- 

Although not requiring a code changes, there were a few other gotcha's under a Windows setup that may be useful in a readme:

1.   Since the websocket module uses a binary the both vim and python had to be either 32bit or 64bit versions.

1. running `pip` with the `python -m` prefix was required:

          python -m pip install websocket-client sexpdata
