### PR TITLE
Close #388: Adds workaround

### DIFF
--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -173,7 +173,9 @@ class NeovimEnsime(Ensime):
 
     @neovim.autocmd('BufEnter', **autocmd_params)
     def au_buf_enter(self, *args, **kwargs):
-        # Workaround for issues #388
+        # Workaround for issue #388
+        # TODO: remove it once the Neovim fix has landed in a stable release
+        # (Github issue to do that: #390)
         self._vim.command('call EnTick()')
         super(NeovimEnsime, self).au_buf_enter(*args, **kwargs)
 

--- a/rplugin/python/ensime.py
+++ b/rplugin/python/ensime.py
@@ -173,9 +173,11 @@ class NeovimEnsime(Ensime):
 
     @neovim.autocmd('BufEnter', **autocmd_params)
     def au_buf_enter(self, *args, **kwargs):
+        # Workaround for issues #388
+        self._vim.command('call EnTick()')
         super(NeovimEnsime, self).au_buf_enter(*args, **kwargs)
 
-    @neovim.function('EnTick', sync=True)
+    @neovim.function('EnTick')
     def tick(self, timer):
         super(NeovimEnsime, self).fun_en_tick(timer)
 


### PR DESCRIPTION
Manual call `EnTick` to force Neovim to register it. We can remove it after the fix has landed in a stable release.