### PR TITLE
Fix #393

### DIFF
--- a/ensime_shared/launcher.py
+++ b/ensime_shared/launcher.py
@@ -285,7 +285,7 @@ class SbtBootstrap(LaunchStrategy):
                               .format(self.classpath_file))
 
         classpath = Util.read_file(self.classpath_file) + ':' + self.toolsjar
-        return self._start_process(classpath)
+        return self._start_process(classpath.split(":"))
 
     # TODO: should maybe check if the build.sbt matches spec (versions, etc.)
     def isinstalled(self):


### PR DESCRIPTION
After f6abb669269646, classpath read from
bootstrap classpath file must be splitted into
a list before to be passed to _start_process.

Signed-off-by: Nick Diego Yamane <nick.diego@gmail.com>