### PR TITLE
Broken Sexp2dict

### DIFF
--- a/ensime_shared/config.py
+++ b/ensime_shared/config.py
@@ -125,8 +125,13 @@ class ProjectConfig(collections.Mapping):
                 key = str(unwrap_if_sexp_symbol(key)).lstrip(':')
 
                 # Recursively transform nested lists
-                if isinstance(value, list) and value and isinstance(value[0], list):
-                    newdict[key] = [sexp2dict(value[0])]
+                if isinstance(value, list) and value:
+                    if isinstance(value[0], list):
+                        newdict[key] = [sexp2dict(val) for val in value]
+                    elif isinstance(value[0], sexpdata.Symbol):
+                        newdict[key] = sexp2dict(value)
+                    else:
+                        newdict[key] = value
                 else:
                     newdict[key] = value
 

--- a/test/resources/test.conf
+++ b/test/resources/test.conf
@@ -1,8 +1,10 @@
 (
  :name "testing"
  :scala-version "2.11.8"
+ :list ("a" "b" "c" "d")
  :nest ((
-  :name "nested"
-  :targets ("abc" "xyz")
-  ))
+  :id (:name "nested1" :config "conf1")
+  :targets ("abc" "xyz")) (
+  :id (:name "nested2" :config "conf2")
+  :targets ("def" "uvw")))
 )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -12,6 +12,9 @@ config = ProjectConfig(confpath.strpath)
 
 def test_parses_dot_ensime():
     assert config.get('scala-version') == '2.11.8'
+    assert config.get('list') == ["a", "b", "c", "d"]
+    assert len(config['nest']) == 2
+    assert config['nest'][0]['id'] == {'config': 'conf1', 'name': 'nested1'}
     assert config['nest'][0]['targets'] == ['abc', 'xyz']
 
 
@@ -26,8 +29,8 @@ def test_knows_its_filepath():
 
 
 def test_is_dict_like():
-    assert set(config.keys()) == set(['name', 'scala-version', 'nest'])
-    assert len(config) == 3
+    assert set(config.keys()) == set(['name', 'scala-version', 'list', 'nest'])
+    assert len(config) == 4
 
 
 def test_fails_when_given_invalid_config():


### PR DESCRIPTION
As per my conversation with @ktonga 
There was an issue in `ProjectConfig`'s parse method's `sexp2dict` method where incase of list of lists in the loaded sexp, only the first element of the list was considered. 