### PR TITLE
Default to use server v2

### DIFF
--- a/ensime_shared/ensime.py
+++ b/ensime_shared/ensime.py
@@ -55,7 +55,7 @@ class Ensime(object):
     @property
     def using_server_v2(self):
         """bool: Whether user has configured the plugin to use ENSIME v2 protocol."""
-        return bool(self.get_setting('server_v2', 0))
+        return bool(self.get_setting('server_v2', 1))
 
     def get_setting(self, key, default):
         """Returns the value of a Vim variable ``g:ensime_{key}``


### PR DESCRIPTION
sbt-ensime has be using 2.0.0-SNAPSHOT as default server version for quite a long time now, so I think we should do the same until we totally remove this legacy setting (#355) as it has been a main point of pain for newcomers, and it's unlikely that someone starting with ensime right now won't want to use v2.