### PR TITLE
avoid the annoying hit-return issue on messages

### DIFF
--- a/ensime_shared/editor.py
+++ b/ensime_shared/editor.py
@@ -321,6 +321,9 @@ class Editor(object):
         cmd = 'echo "{}"'.format(message.replace('"', '\\"'))
         if silent:
             cmd = 'silent ' + cmd
+        cmd = "let _ensime_showcmd=&showcmd | set noshowcmd | let _ensime_ruler=&ruler | set noruler | " + \
+		cmd + \
+		" | let &showcmd=_ensime_showcmd | let &ruler=_ensime_ruler"
 
         if self.isneovim:
             vim.async_call(vim.command, cmd)


### PR DESCRIPTION
a quickfix to avoid hit-return messages in vim (neovim) when echoing messages of correct length.

disables showcmd and ruler as they are being checked here: https://github.com/neovim/neovim/blob/7795829767818a3c6cbeed7957a1ad5c03d48d41/src/nvim/option.c#L5284 
once echoed, restores the state