### PR TITLE
Use integer division to get indices for the error message

### DIFF
--- a/ensime_shared/errors.py
+++ b/ensime_shared/errors.py
@@ -36,8 +36,8 @@ class Error(object):
             return self.message
         percent = float(cursor[1] - self.c) / (self.e - self.c)
         center = int(percent * size)
-        start = center - width / 2
-        end = center + width / 2
+        start = center - width // 2
+        end = center + width // 2
         if start < 0:
             start = 0
             end = width


### PR DESCRIPTION
Use // instead of /, as sometimes the indices ended up as floating points.